### PR TITLE
Upgrade all classes to support spec 3.16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,8 @@ jobs:
         run: ./vendor/bin/phpcs -n
       - name: phpstan
         run: ./vendor/bin/phpstan
+      - name: psalm
+        run: ./vendor/bin/psalm
 #      - name: phan
 #        run: ./vendor/bin/phan
 #      - name: phpunit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           extensions: ${{ matrix.xdebug }}, ast
           tools: composer
       - name: Composer Install
-        run: composer install --prefer-dist --no-interaction
+        run: COMPOSER_ROOT_VERSION=dev-main composer install --prefer-dist --no-interaction
       - name: phpcs
         run: ./vendor/bin/phpcs -n
       - name: phpstan

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,9 @@
     "prefer-stable": true,
     "scripts":
     {
-        "phpstan": "./vendor/bin/phpstan analyse -c phpstan.neon --ansi --level=7 -vvv src",
-        "psalm": "./vendor/bin/psalm"
+        "phpstan": "phpstan analyse -c phpstan.neon --ansi --level=7 -vvv src",
+        "psalm": "psalm",
+        "phpcs": "phpcs",
+        "phpcbf": "phpcbf"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.x-dev"
+            "dev-main": "1.x-dev",
+            "dev-feature/spec-3.16-zobo": "1.x-dev"
         }
     },
     "minimum-stability": "dev",

--- a/src/CallHierarchyClientCapabilities.php
+++ b/src/CallHierarchyClientCapabilities.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class CallHierarchyClientCapabilities
+{
+
+	/**
+	 * Whether implementation supports dynamic registration. If this is set to
+	 * `true` the client supports the new `(TextDocumentRegistrationOptions &
+	 * StaticRegistrationOptions)` return value for the corresponding server
+	 * capability as well.
+	 *
+	 * @var bool|null
+	 */
+    public $dynamicRegistration;
+
+	public function __construct(?bool $dynamicRegistration = null)
+	{
+		$this->dynamicRegistration = $dynamicRegistration;
+	}
+
+}

--- a/src/CallHierarchyClientCapabilities.php
+++ b/src/CallHierarchyClientCapabilities.php
@@ -5,19 +5,18 @@ namespace LanguageServerProtocol;
 class CallHierarchyClientCapabilities
 {
 
-	/**
-	 * Whether implementation supports dynamic registration. If this is set to
-	 * `true` the client supports the new `(TextDocumentRegistrationOptions &
-	 * StaticRegistrationOptions)` return value for the corresponding server
-	 * capability as well.
-	 *
-	 * @var bool|null
-	 */
+    /**
+     * Whether implementation supports dynamic registration. If this is set to
+     * `true` the client supports the new `(TextDocumentRegistrationOptions &
+     * StaticRegistrationOptions)` return value for the corresponding server
+     * capability as well.
+     *
+     * @var bool|null
+     */
     public $dynamicRegistration;
 
-	public function __construct(?bool $dynamicRegistration = null)
-	{
-		$this->dynamicRegistration = $dynamicRegistration;
-	}
-
+    public function __construct(?bool $dynamicRegistration = null)
+    {
+        $this->dynamicRegistration = $dynamicRegistration;
+    }
 }

--- a/src/ChangeAnnotation.php
+++ b/src/ChangeAnnotation.php
@@ -6,33 +6,34 @@ class ChangeAnnotation
 {
 
 /**
-	 * A human-readable string describing the actual change. The string
-	 * is rendered prominent in the user interface.
-	 *
-	 * @var string
-	 */
-	public $label;
+     * A human-readable string describing the actual change. The string
+     * is rendered prominent in the user interface.
+     *
+     * @var string
+     */
+    public $label;
 
-	/**
-	 * A flag which indicates that user confirmation is needed
-	 * before applying the change.
-	 *
-	 * @var bool|null
-	 */
-	public $needsConfirmation;
+    /**
+     * A flag which indicates that user confirmation is needed
+     * before applying the change.
+     *
+     * @var bool|null
+     */
+    public $needsConfirmation;
 
-	/**
-	 * A human-readable string which is rendered less prominent in
-	 * the user interface.
-	 *
-	 * @var string|null
-	 */
-	public $description;
+    /**
+     * A human-readable string which is rendered less prominent in
+     * the user interface.
+     *
+     * @var string|null
+     */
+    public $description;
 
-	public function __construct(string $label, bool $needsConfirmation = null, string $description = null)
-	{
-		$this->label = $label;
-		$this->needsConfirmation = $needsConfirmation;
-		$this->description = $description;
-	}
+    public function __construct(string $label = null, bool $needsConfirmation = null, string $description = null)
+    {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
+        $this->label = $label;
+        $this->needsConfirmation = $needsConfirmation;
+        $this->description = $description;
+    }
 }

--- a/src/ChangeAnnotation.php
+++ b/src/ChangeAnnotation.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class ChangeAnnotation
+{
+
+/**
+	 * A human-readable string describing the actual change. The string
+	 * is rendered prominent in the user interface.
+	 *
+	 * @var string
+	 */
+	public $label;
+
+	/**
+	 * A flag which indicates that user confirmation is needed
+	 * before applying the change.
+	 *
+	 * @var bool|null
+	 */
+	public $needsConfirmation;
+
+	/**
+	 * A human-readable string which is rendered less prominent in
+	 * the user interface.
+	 *
+	 * @var string|null
+	 */
+	public $description;
+
+	public function __construct(string $label, bool $needsConfirmation = null, string $description = null)
+	{
+		$this->label = $label;
+		$this->needsConfirmation = $needsConfirmation;
+		$this->description = $description;
+	}
+}

--- a/src/ClientCapabilities.php
+++ b/src/ClientCapabilities.php
@@ -4,31 +4,64 @@ namespace LanguageServerProtocol;
 
 class ClientCapabilities
 {
-    /**
-     * The client supports workspace/xfiles requests
-     *
-     * @var bool|null
-     */
-    public $xfilesProvider;
 
     /**
-     * The client supports textDocument/xcontent requests
+     * Workspace specific client capabilities.
      *
-     * @var bool|null
+     * @var ClientCapabilitiesWorkspace|null
      */
-    public $xcontentProvider;
+    public $workspace;
 
     /**
-     * The client supports xcache/* requests
+     * Text document specific client capabilities.
      *
-     * @var bool|null
+     * @var TextDocumentClientCapabilities|null
      */
-    public $xcacheProvider;
+    public $textDocument;
 
-    public function __construct(bool $xfilesProvider = null, bool $xcontentProvider = null, bool $xcacheProvider = null)
-    {
-        $this->xfilesProvider = $xfilesProvider;
-        $this->xcontentProvider = $xcontentProvider;
-        $this->xcacheProvider = $xcacheProvider;
+    /**
+     * Window specific client capabilities.
+     *
+     * @var ClientCapabilitiesWindow|null
+     */
+    public $window;
+
+    /**
+     * General client capabilities.
+     *
+     * @since 3.16.0
+     *
+     * @var ClientCapabilitiesGeneral|null
+     */
+    public $general;
+
+    /**
+	 * Experimental client capabilities.
+     *
+     * @var mixed|null
+	 */
+	public $experimental;
+
+    /**
+     * Undocumented function
+     *
+     * @param ClientCapabilitiesWorkspace|null $workspace
+     * @param TextDocumentClientCapabilities|null $textDocument
+     * @param ClientCapabilitiesWindow|null $window
+     * @param ClientCapabilitiesGeneral|null $general
+     * @param mixed|null $experimental
+     */
+    public function __construct(
+        ClientCapabilitiesWorkspace $workspace = null,
+        TextDocumentClientCapabilities $textDocument = null,
+        ClientCapabilitiesWindow $window = null,
+        ClientCapabilitiesGeneral $general = null,
+        $experimental = null
+    ) {
+        $this->workspace = $workspace;
+        $this->textDocument = $textDocument;
+        $this->window = $window;
+        $this->general = $general;
+        $this->experimental = $experimental;
     }
 }

--- a/src/ClientCapabilities.php
+++ b/src/ClientCapabilities.php
@@ -36,11 +36,11 @@ class ClientCapabilities
     public $general;
 
     /**
-	 * Experimental client capabilities.
+     * Experimental client capabilities.
      *
      * @var mixed|null
-	 */
-	public $experimental;
+     */
+    public $experimental;
 
     /**
      * Undocumented function

--- a/src/ClientCapabilitiesGeneral.php
+++ b/src/ClientCapabilitiesGeneral.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class ClientCapabilitiesGeneral
+{
+    /**
+     * Client capabilities specific to regular expressions.
+     *
+     * @since 3.16.0
+     *
+     * @var RegularExpressionsClientCapabilities|null
+     */
+    public $regularExpressions;
+
+    /**
+     * Client capabilities specific to the client's markdown parser.
+     *
+     * @since 3.16.0
+     *
+     * @var MarkdownClientCapabilities|null
+     */
+    public $markdown;
+
+
+    public function __construct(
+        RegularExpressionsClientCapabilities $regularExpressions = null,
+        MarkdownClientCapabilities $markdown = null
+    ) {
+        $this->regularExpressions = $regularExpressions;
+        $this->markdown = $markdown;
+    }
+}

--- a/src/ClientCapabilitiesWindow.php
+++ b/src/ClientCapabilitiesWindow.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class ClientCapabilitiesWindow
+{
+
+    /**
+     * Whether client supports handling progress notifications. If set
+     * servers are allowed to report in `workDoneProgress` property in the
+     * request specific server capabilities.
+     *
+     * @since 3.15.0
+     *
+     * @var boolean|null
+     */
+    public $workDoneProgress;
+
+    /**
+     * Capabilities specific to the showMessage request
+     *
+     * @since 3.16.0
+     *
+     * @var ShowMessageRequestClientCapabilities|null
+     */
+    public $showMessage;
+
+    /**
+     * Client capabilities for the show document request.
+     *
+     * @since 3.16.0
+     *
+     * @var ShowDocumentClientCapabilities|null
+     */
+    public $showDocument;
+
+
+    public function __construct(
+        bool $workDoneProgress = null,
+        ShowMessageRequestClientCapabilities $showMessage = null,
+        ShowDocumentClientCapabilities $showDocument = null
+    ) {
+        $this->workDoneProgress = $workDoneProgress;
+        $this->showMessage = $showMessage;
+        $this->showDocument = $showDocument;
+    }
+}

--- a/src/ClientCapabilitiesWorkspace.php
+++ b/src/ClientCapabilitiesWorkspace.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class ClientCapabilitiesWorkspace
+{
+    /**
+     * The client supports applying batch edits
+     * to the workspace by supporting the request
+     * 'workspace/applyEdit'
+     *
+     * @var bool|null
+     */
+    public $applyEdit;
+
+    /**
+     * Capabilities specific to `WorkspaceEdit`s
+     *
+     * @var WorkspaceEditClientCapabilities|null
+     */
+    public $workspaceEdit;
+
+    /**
+     * Capabilities specific to the `workspace/didChangeConfiguration`
+     * notification.
+     *
+     * @var DidChangeConfigurationClientCapabilities|null
+     */
+    public $didChangeConfiguration;
+
+    /**
+     * Capabilities specific to the `workspace/didChangeWatchedFiles`
+     * notification.
+     *
+     * @var DidChangeWatchedFilesClientCapabilities|null
+     */
+    public $didChangeWatchedFiles;
+
+    /**
+     * Capabilities specific to the `workspace/symbol` request.
+     *
+     * @var WorkspaceSymbolClientCapabilities|null
+     */
+    public $symbol;
+
+    /**
+     * Capabilities specific to the `workspace/executeCommand` request.
+     *
+     * @var ExecuteCommandClientCapabilities|null
+     */
+    public $executeCommand;
+
+    /**
+     * The client has support for workspace folders.
+     *
+     * @since 3.6.0
+     *
+     * @var bool|null
+     */
+    public $workspaceFolders;
+
+    /**
+     * The client supports `workspace/configuration` requests.
+     *
+     * @since 3.6.0
+     *
+     * @var bool|null
+     */
+    public $configuration;
+
+    /**
+     * Capabilities specific to the semantic token requests scoped to the
+     * workspace.
+     *
+     * @since 3.16.0
+     *
+     * @var SemanticTokensWorkspaceClientCapabilities|null
+     */
+    public $semanticTokens;
+
+    /**
+     * Capabilities specific to the code lens requests scoped to the
+     * workspace.
+     *
+     * @since 3.16.0
+     *
+     * @var CodeLensWorkspaceClientCapabilities|null
+     */
+    public $codeLens;
+
+    /**
+     * The client has support for file requests/notifications.
+     *
+     * @since 3.16.0
+     *
+     * @var ClientCapabilitiesWorkspaceFileOperations|null
+     */
+    public $fileOperations;
+}

--- a/src/ClientCapabilitiesWorkspaceFileOperations.php
+++ b/src/ClientCapabilitiesWorkspaceFileOperations.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class ClientCapabilitiesWorkspaceFileOperations
+{
+
+    /**
+     * Whether the client supports dynamic registration for file
+     * requests/notifications.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    /**
+     * The client has support for sending didCreateFiles notifications.
+     *
+     * @var bool|null
+     */
+    public $didCreate;
+
+    /**
+     * The client has support for sending willCreateFiles requests.
+     *
+     * @var bool|null
+     */
+    public $willCreate;
+
+    /**
+     * The client has support for sending didRenameFiles notifications.
+     *
+     * @var bool|null
+     */
+    public $didRename;
+
+    /**
+     * The client has support for sending willRenameFiles requests.
+     *
+     * @var bool|null
+     */
+    public $willRename;
+
+    /**
+     * The client has support for sending didDeleteFiles notifications.
+     *
+     * @var bool|null
+     */
+    public $didDelete;
+
+    /**
+     * The client has support for sending willDeleteFiles requests.
+     *
+     * @var bool|null
+     */
+    public $willDelete;
+
+    public function __construct(
+        bool $dynamicRegistration = null,
+        bool $didCreate = null,
+        bool $willCreate = null,
+        bool $didRename = null,
+        bool $willRename = null,
+        bool $didDelete = null,
+        bool $willDelete = null
+    ) {
+        $this->dynamicRegistration = $dynamicRegistration;
+        $this->didCreate = $didCreate;
+        $this->willCreate = $willCreate;
+        $this->didRename = $didRename;
+        $this->willRename = $willRename;
+        $this->didDelete = $didDelete;
+        $this->willDelete = $willDelete;
+    }
+}

--- a/src/ClientInfo.php
+++ b/src/ClientInfo.php
@@ -17,4 +17,12 @@ class ClientInfo
      * @var string|null
      */
     public $version;
+
+    public function __construct(
+        string $name,
+        string $version = null
+    ) {
+        $this->name = $name;
+        $this->version = $version;
+    }
 }

--- a/src/ClientInfo.php
+++ b/src/ClientInfo.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class ClientInfo
+{
+    /**
+     * The name of the client as defined by the client.
+     *
+     * @var string
+     */
+    public $name;
+
+    /**
+     * The client's version as defined by the client.
+     *
+     * @var string|null
+     */
+    public $version;
+}

--- a/src/ClientInfo.php
+++ b/src/ClientInfo.php
@@ -19,9 +19,10 @@ class ClientInfo
     public $version;
 
     public function __construct(
-        string $name,
+        string $name = null,
         string $version = null
     ) {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->name = $name;
         $this->version = $version;
     }

--- a/src/CodeAction.php
+++ b/src/CodeAction.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+use JsonSerializable;
+
+/**
+ * A code action represents a change that can be performed in code, e.g. to fix
+ * a problem or to refactor code.
+ *
+ * A CodeAction must set either `edit` and/or a `command`. If both are supplied,
+ * the `edit` is applied first, then the `command` is executed.
+ */
+class CodeAction implements JsonSerializable
+{
+    /**
+	 * A short, human-readable, title for this code action.
+	 *
+	 * @var string
+	 */
+	public $title;
+
+	/**
+	 * The kind of the code action.
+	 *
+	 * Used to filter code actions.
+	 *
+	 * @var string|null
+	 * @see CodeActionKind
+	 */
+	public $kind;
+
+	/**
+	 * The diagnostics that this code action resolves.
+	 * @var Diagnostic[]|null
+	 */
+	public $diagnostics;
+
+	/**
+	 * Marks this as a preferred action. Preferred actions are used by the
+	 * `auto fix` command and can be targeted by keybindings.
+	 *
+	 * A quick fix should be marked preferred if it properly addresses the
+	 * underlying error. A refactoring should be marked preferred if it is the
+	 * most reasonable choice of actions to take.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @var bool|null
+	 */
+	public $isPreferred;
+
+	/**
+	 * Marks that the code action cannot currently be applied.
+	 *
+	 * Clients should follow the following guidelines regarding disabled code
+	 * actions:
+	 *
+	 * - Disabled code actions are not shown in automatic lightbulbs code
+	 *   action menus.
+	 *
+	 * - Disabled actions are shown as faded out in the code action menu when
+	 *   the user request a more specific type of code action, such as
+	 *   refactorings.
+	 *
+	 * - If the user has a keybinding that auto applies a code action and only
+	 *   a disabled code actions are returned, the client should show the user
+	 *   an error message with `reason` in the editor.
+	 *
+	 * @since 3.16.0
+	 *
+	 * @var CodeActionDisabled|null
+	 */
+	public $disabled;
+
+	/**
+	 * The workspace edit this code action performs.
+	 *
+	 * @var WorkspaceEdit|null
+	 */
+	public $edit;
+
+	/**
+	 * A command this code action executes. If a code action
+	 * provides an edit and a command, first the edit is
+	 * executed and then the command.
+	 *
+	 * @var Command|null
+	 */
+	public $command;
+
+	/**
+	 * A data entry field that is preserved on a code action between
+	 * a `textDocument/codeAction` and a `codeAction/resolve` request.
+	 *
+	 * @since 3.16.0
+	 *
+	 * @var mixed|null
+	 */
+	public $data;
+
+	public function __construct(
+		string $title,
+		string $kind = null,
+		array $diagnostics = null,
+		bool $isPreferred = null,
+		CodeActionDisabled $disabled = null,
+		WorkspaceEdit $edit = null,
+		Command $command = null,
+		$data = null
+	) {
+		$this->title = $title;
+		$this->kind = $kind;
+		$this->diagnostics = $diagnostics;
+		$this->isPreferred = $isPreferred;
+		$this->disabled = $disabled;
+		$this->edit = $edit;
+		$this->command = $command;
+		$this->data = $data;
+	}
+
+	/**
+	 * This is needed because VSCode Does not like nulls
+	 * meaning if a null is sent then this will not compute
+	 *
+	 * @return mixed
+	 */
+	#[\ReturnTypeWillChange]
+	public function jsonSerialize()
+	{
+		return array_filter(get_object_vars($this));
+	}
+}

--- a/src/CodeAction.php
+++ b/src/CodeAction.php
@@ -14,132 +14,133 @@ use JsonSerializable;
 class CodeAction implements JsonSerializable
 {
     /**
-	 * A short, human-readable, title for this code action.
-	 *
-	 * @var string
-	 */
-	public $title;
+     * A short, human-readable, title for this code action.
+     *
+     * @var string
+     */
+    public $title;
 
-	/**
-	 * The kind of the code action.
-	 *
-	 * Used to filter code actions.
-	 *
-	 * @var string|null
-	 * @see CodeActionKind
-	 */
-	public $kind;
+    /**
+     * The kind of the code action.
+     *
+     * Used to filter code actions.
+     *
+     * @var string|null
+     * @see CodeActionKind
+     */
+    public $kind;
 
-	/**
-	 * The diagnostics that this code action resolves.
-	 * @var Diagnostic[]|null
-	 */
-	public $diagnostics;
+    /**
+     * The diagnostics that this code action resolves.
+     * @var Diagnostic[]|null
+     */
+    public $diagnostics;
 
-	/**
-	 * Marks this as a preferred action. Preferred actions are used by the
-	 * `auto fix` command and can be targeted by keybindings.
-	 *
-	 * A quick fix should be marked preferred if it properly addresses the
-	 * underlying error. A refactoring should be marked preferred if it is the
-	 * most reasonable choice of actions to take.
-	 *
-	 * @since 3.15.0
-	 *
-	 * @var bool|null
-	 */
-	public $isPreferred;
+    /**
+     * Marks this as a preferred action. Preferred actions are used by the
+     * `auto fix` command and can be targeted by keybindings.
+     *
+     * A quick fix should be marked preferred if it properly addresses the
+     * underlying error. A refactoring should be marked preferred if it is the
+     * most reasonable choice of actions to take.
+     *
+     * @since 3.15.0
+     *
+     * @var bool|null
+     */
+    public $isPreferred;
 
-	/**
-	 * Marks that the code action cannot currently be applied.
-	 *
-	 * Clients should follow the following guidelines regarding disabled code
-	 * actions:
-	 *
-	 * - Disabled code actions are not shown in automatic lightbulbs code
-	 *   action menus.
-	 *
-	 * - Disabled actions are shown as faded out in the code action menu when
-	 *   the user request a more specific type of code action, such as
-	 *   refactorings.
-	 *
-	 * - If the user has a keybinding that auto applies a code action and only
-	 *   a disabled code actions are returned, the client should show the user
-	 *   an error message with `reason` in the editor.
-	 *
-	 * @since 3.16.0
-	 *
-	 * @var CodeActionDisabled|null
-	 */
-	public $disabled;
+    /**
+     * Marks that the code action cannot currently be applied.
+     *
+     * Clients should follow the following guidelines regarding disabled code
+     * actions:
+     *
+     * - Disabled code actions are not shown in automatic lightbulbs code
+     *   action menus.
+     *
+     * - Disabled actions are shown as faded out in the code action menu when
+     *   the user request a more specific type of code action, such as
+     *   refactorings.
+     *
+     * - If the user has a keybinding that auto applies a code action and only
+     *   a disabled code actions are returned, the client should show the user
+     *   an error message with `reason` in the editor.
+     *
+     * @since 3.16.0
+     *
+     * @var CodeActionDisabled|null
+     */
+    public $disabled;
 
-	/**
-	 * The workspace edit this code action performs.
-	 *
-	 * @var WorkspaceEdit|null
-	 */
-	public $edit;
+    /**
+     * The workspace edit this code action performs.
+     *
+     * @var WorkspaceEdit|null
+     */
+    public $edit;
 
-	/**
-	 * A command this code action executes. If a code action
-	 * provides an edit and a command, first the edit is
-	 * executed and then the command.
-	 *
-	 * @var Command|null
-	 */
-	public $command;
+    /**
+     * A command this code action executes. If a code action
+     * provides an edit and a command, first the edit is
+     * executed and then the command.
+     *
+     * @var Command|null
+     */
+    public $command;
 
-	/**
-	 * A data entry field that is preserved on a code action between
-	 * a `textDocument/codeAction` and a `codeAction/resolve` request.
-	 *
-	 * @since 3.16.0
-	 *
-	 * @var mixed|null
-	 */
-	public $data;
+    /**
+     * A data entry field that is preserved on a code action between
+     * a `textDocument/codeAction` and a `codeAction/resolve` request.
+     *
+     * @since 3.16.0
+     *
+     * @var mixed|null
+     */
+    public $data;
 
-	/**
-	 * Undocumented function
-	 *
-	 * @param string $title
-	 * @param string|null $kind
-	 * @param Diagnostic[]|null $diagnostics
-	 * @param boolean|null $isPreferred
-	 * @param CodeActionDisabled|null $disabled
-	 * @param WorkspaceEdit|null $edit
-	 * @param Command|null $command
-	 * @param mixed $data
-	 */
-	public function __construct(
-		string $title,
-		string $kind = null,
-		array $diagnostics = null,
-		bool $isPreferred = null,
-		CodeActionDisabled $disabled = null,
-		WorkspaceEdit $edit = null,
-		Command $command = null,
-		$data = null
-	) {
-		$this->title = $title;
-		$this->kind = $kind;
-		$this->diagnostics = $diagnostics;
-		$this->isPreferred = $isPreferred;
-		$this->disabled = $disabled;
-		$this->edit = $edit;
-		$this->command = $command;
-		$this->data = $data;
-	}
+    /**
+     * Undocumented function
+     *
+     * @param string|null $title
+     * @param string|null $kind
+     * @param Diagnostic[]|null $diagnostics
+     * @param boolean|null $isPreferred
+     * @param CodeActionDisabled|null $disabled
+     * @param WorkspaceEdit|null $edit
+     * @param Command|null $command
+     * @param mixed $data
+     */
+    public function __construct(
+        string $title = null,
+        string $kind = null,
+        array $diagnostics = null,
+        bool $isPreferred = null,
+        CodeActionDisabled $disabled = null,
+        WorkspaceEdit $edit = null,
+        Command $command = null,
+        $data = null
+    ) {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
+        $this->title = $title;
+        $this->kind = $kind;
+        $this->diagnostics = $diagnostics;
+        $this->isPreferred = $isPreferred;
+        $this->disabled = $disabled;
+        $this->edit = $edit;
+        $this->command = $command;
+        $this->data = $data;
+    }
 
-	/**
-	 * This is needed because VSCode Does not like nulls
-	 * meaning if a null is sent then this will not compute
-	 *
-	 * @return mixed
-	 */
-	#[\ReturnTypeWillChange]
-	public function jsonSerialize()
-	{
-		return array_filter(get_object_vars($this));
-	}
+    /**
+     * This is needed because VSCode Does not like nulls
+     * meaning if a null is sent then this will not compute
+     *
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+        return array_filter(get_object_vars($this));
+    }
 }

--- a/src/CodeAction.php
+++ b/src/CodeAction.php
@@ -99,6 +99,18 @@ class CodeAction implements JsonSerializable
 	 */
 	public $data;
 
+	/**
+	 * Undocumented function
+	 *
+	 * @param string $title
+	 * @param string|null $kind
+	 * @param Diagnostic[]|null $diagnostics
+	 * @param boolean|null $isPreferred
+	 * @param CodeActionDisabled|null $disabled
+	 * @param WorkspaceEdit|null $edit
+	 * @param Command|null $command
+	 * @param mixed $data
+	 */
 	public function __construct(
 		string $title,
 		string $kind = null,

--- a/src/CodeActionClientCapabilities.php
+++ b/src/CodeActionClientCapabilities.php
@@ -12,84 +12,84 @@ class CodeActionClientCapabilities
      */
     public $dynamicRegistration;
 
-	/**
-	 * The client supports code action literals as a valid
-	 * response of the `textDocument/codeAction` request.
-	 *
-	 * @since 3.8.0
-	 *
-	 * @var CodeActionClientCapabilitiesCodeActionLiteralSupport|null
-	 */
-	public $codeActionLiteralSupport;
+    /**
+     * The client supports code action literals as a valid
+     * response of the `textDocument/codeAction` request.
+     *
+     * @since 3.8.0
+     *
+     * @var CodeActionClientCapabilitiesCodeActionLiteralSupport|null
+     */
+    public $codeActionLiteralSupport;
 
-	/**
-	 * Whether code action supports the `isPreferred` property.
-	 *
-	 * @since 3.15.0
+    /**
+     * Whether code action supports the `isPreferred` property.
+     *
+     * @since 3.15.0
      *
      * @var bool|null
      */
-	public $isPreferredSupport;
+    public $isPreferredSupport;
 
-	/**
-	 * Whether code action supports the `disabled` property.
-	 *
-	 * @since 3.16.0
+    /**
+     * Whether code action supports the `disabled` property.
+     *
+     * @since 3.16.0
      *
      * @var bool|null
      */
-	public $disabledSupport;
+    public $disabledSupport;
 
-	/**
-	 * Whether code action supports the `data` property which is
-	 * preserved between a `textDocument/codeAction` and a
-	 * `codeAction/resolve` request.
-	 *
-	 * @since 3.16.0
+    /**
+     * Whether code action supports the `data` property which is
+     * preserved between a `textDocument/codeAction` and a
+     * `codeAction/resolve` request.
+     *
+     * @since 3.16.0
      *
      * @var bool|null
      */
-	public $dataSupport;
+    public $dataSupport;
 
 
-	/**
-	 * Whether the client supports resolving additional code action
-	 * properties via a separate `codeAction/resolve` request.
-	 *
-	 * @since 3.16.0
-	 *
-	 * @var CodeActionClientCapabilitiesResolveSupport|null
-	 */
-	public $resolveSupport;
+    /**
+     * Whether the client supports resolving additional code action
+     * properties via a separate `codeAction/resolve` request.
+     *
+     * @since 3.16.0
+     *
+     * @var CodeActionClientCapabilitiesResolveSupport|null
+     */
+    public $resolveSupport;
 
-	/**
-	 * Whether the client honors the change annotations in
-	 * text edits and resource operations returned via the
-	 * `CodeAction#edit` property by for example presenting
-	 * the workspace edit in the user interface and asking
-	 * for confirmation.
-	 *
-	 * @since 3.16.0
+    /**
+     * Whether the client honors the change annotations in
+     * text edits and resource operations returned via the
+     * `CodeAction#edit` property by for example presenting
+     * the workspace edit in the user interface and asking
+     * for confirmation.
+     *
+     * @since 3.16.0
      *
      * @var bool|null
      */
-	public $honorsChangeAnnotations;
+    public $honorsChangeAnnotations;
 
-	public function __construct(
-		bool $dynamicRegistration = null,
-		CodeActionClientCapabilitiesCodeActionLiteralSupport $codeActionLiteralSupport = null,
-		bool $isPreferredSupport = null,
-		bool $disabledSupport = null,
-		bool $dataSupport = null,
-		CodeActionClientCapabilitiesResolveSupport $resolveSupport = null,
-		bool $honorsChangeAnnotations = null
-	) {
-		$this->dynamicRegistration = $dynamicRegistration;
-		$this->codeActionLiteralSupport = $codeActionLiteralSupport;
-		$this->isPreferredSupport = $isPreferredSupport;
-		$this->disabledSupport = $disabledSupport;
-		$this->dataSupport = $dataSupport;
-		$this->resolveSupport = $resolveSupport;
-		$this->honorsChangeAnnotations = $honorsChangeAnnotations;
-	}
+    public function __construct(
+        bool $dynamicRegistration = null,
+        CodeActionClientCapabilitiesCodeActionLiteralSupport $codeActionLiteralSupport = null,
+        bool $isPreferredSupport = null,
+        bool $disabledSupport = null,
+        bool $dataSupport = null,
+        CodeActionClientCapabilitiesResolveSupport $resolveSupport = null,
+        bool $honorsChangeAnnotations = null
+    ) {
+        $this->dynamicRegistration = $dynamicRegistration;
+        $this->codeActionLiteralSupport = $codeActionLiteralSupport;
+        $this->isPreferredSupport = $isPreferredSupport;
+        $this->disabledSupport = $disabledSupport;
+        $this->dataSupport = $dataSupport;
+        $this->resolveSupport = $resolveSupport;
+        $this->honorsChangeAnnotations = $honorsChangeAnnotations;
+    }
 }

--- a/src/CodeActionClientCapabilities.php
+++ b/src/CodeActionClientCapabilities.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class CodeActionClientCapabilities
+{
+
+    /**
+     * Whether code action supports dynamic registration.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+	/**
+	 * The client supports code action literals as a valid
+	 * response of the `textDocument/codeAction` request.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @var CodeActionClientCapabilitiesCodeActionLiteralSupport|null
+	 */
+	public $codeActionLiteralSupport;
+
+	/**
+	 * Whether code action supports the `isPreferred` property.
+	 *
+	 * @since 3.15.0
+     *
+     * @var bool|null
+     */
+	public $isPreferredSupport;
+
+	/**
+	 * Whether code action supports the `disabled` property.
+	 *
+	 * @since 3.16.0
+     *
+     * @var bool|null
+     */
+	public $disabledSupport;
+
+	/**
+	 * Whether code action supports the `data` property which is
+	 * preserved between a `textDocument/codeAction` and a
+	 * `codeAction/resolve` request.
+	 *
+	 * @since 3.16.0
+     *
+     * @var bool|null
+     */
+	public $dataSupport;
+
+
+	/**
+	 * Whether the client supports resolving additional code action
+	 * properties via a separate `codeAction/resolve` request.
+	 *
+	 * @since 3.16.0
+	 *
+	 * @var CodeActionClientCapabilitiesResolveSupport|null
+	 */
+	public $resolveSupport;
+
+	/**
+	 * Whether the client honors the change annotations in
+	 * text edits and resource operations returned via the
+	 * `CodeAction#edit` property by for example presenting
+	 * the workspace edit in the user interface and asking
+	 * for confirmation.
+	 *
+	 * @since 3.16.0
+     *
+     * @var bool|null
+     */
+	public $honorsChangeAnnotations;
+
+	public function __construct(
+		bool $dynamicRegistration = null,
+		CodeActionClientCapabilitiesCodeActionLiteralSupport $codeActionLiteralSupport = null,
+		bool $isPreferredSupport = null,
+		bool $disabledSupport = null,
+		bool $dataSupport = null,
+		CodeActionClientCapabilitiesResolveSupport $resolveSupport = null,
+		bool $honorsChangeAnnotations = null
+	) {
+		$this->dynamicRegistration = $dynamicRegistration;
+		$this->codeActionLiteralSupport = $codeActionLiteralSupport;
+		$this->isPreferredSupport = $isPreferredSupport;
+		$this->disabledSupport = $disabledSupport;
+		$this->dataSupport = $dataSupport;
+		$this->resolveSupport = $resolveSupport;
+		$this->honorsChangeAnnotations = $honorsChangeAnnotations;
+	}
+}

--- a/src/CodeActionClientCapabilitiesCodeActionLiteralSupport.php
+++ b/src/CodeActionClientCapabilitiesCodeActionLiteralSupport.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class CodeActionClientCapabilitiesCodeActionLiteralSupport
+{
+
+    /**
+     * The code action kind is supported with the following value
+     * set.
+     *
+     * @var CodeActionClientCapabilitiesCodeActionLiteralSupportcodeActionKind
+     */
+    public $codeActionKind;
+
+    public function __construct(CodeActionClientCapabilitiesCodeActionLiteralSupportcodeActionKind $codeActionKind)
+    {
+        $this->codeActionKind = $codeActionKind;
+    }
+}

--- a/src/CodeActionClientCapabilitiesCodeActionLiteralSupportcodeActionKind.php
+++ b/src/CodeActionClientCapabilitiesCodeActionLiteralSupportcodeActionKind.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class CodeActionClientCapabilitiesCodeActionLiteralSupportcodeActionKind
+{
+
+    /**
+     * The code action kind values the client supports. When this
+     * property exists the client also guarantees that it will
+     * handle values outside its set gracefully and falls back
+     * to a default value when unknown.
+     *
+     * @var string[]
+     * @see CodeActionKind
+     */
+    public $valueSet;
+
+    /**
+     * Undocumented function
+     *
+     * @param string[] $valueSet
+     */
+    public function __construct(array $valueSet)
+    {
+        $this->valueSet = $valueSet;
+    }
+}

--- a/src/CodeActionClientCapabilitiesResolveSupport.php
+++ b/src/CodeActionClientCapabilitiesResolveSupport.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class CodeActionClientCapabilitiesResolveSupport
+{
+    /**
+     * The properties that a client can resolve lazily.
+     *
+     * @var string[]
+     */
+    public $properties;
+
+    /**
+     * @param string[] $properties
+     */
+    public function __construct(array $properties)
+    {
+        $this->properties = $properties;
+    }
+}

--- a/src/CodeActionContext.php
+++ b/src/CodeActionContext.php
@@ -9,37 +9,37 @@ namespace LanguageServerProtocol;
 class CodeActionContext
 {
     /**
-	 * An array of diagnostics known on the client side overlapping the range
-	 * provided to the `textDocument/codeAction` request. They are provided so
-	 * that the server knows which errors are currently presented to the user
-	 * for the given range. There is no guarantee that these accurately reflect
-	 * the error state of the resource. The primary parameter
-	 * to compute code actions is the provided range.
+     * An array of diagnostics known on the client side overlapping the range
+     * provided to the `textDocument/codeAction` request. They are provided so
+     * that the server knows which errors are currently presented to the user
+     * for the given range. There is no guarantee that these accurately reflect
+     * the error state of the resource. The primary parameter
+     * to compute code actions is the provided range.
      *
      * @var Diagnostic[]
      */
     public $diagnostics;
 
     /**
-	 * Requested kind of actions to return.
-	 *
-	 * Actions not of this kind are filtered out by the client before being
-	 * shown. So servers can omit computing them.
+     * Requested kind of actions to return.
+     *
+     * Actions not of this kind are filtered out by the client before being
+     * shown. So servers can omit computing them.
      *
      * @var string[]|null
      * @see CodeActionKind
-	 */
-	public $only;
+     */
+    public $only;
 
-	/**
-	 * The reason why code actions were requested.
-	 *
-	 * @since 3.17.0
+    /**
+     * The reason why code actions were requested.
+     *
+     * @since 3.17.0
      *
      * @var int|null
      * @see CodeActionTriggerKind
-	 */
-	public $triggerKind;
+     */
+    public $triggerKind;
 
     /**
      * @param Diagnostic[] $diagnostics

--- a/src/CodeActionContext.php
+++ b/src/CodeActionContext.php
@@ -9,11 +9,37 @@ namespace LanguageServerProtocol;
 class CodeActionContext
 {
     /**
-     * An array of diagnostics.
+	 * An array of diagnostics known on the client side overlapping the range
+	 * provided to the `textDocument/codeAction` request. They are provided so
+	 * that the server knows which errors are currently presented to the user
+	 * for the given range. There is no guarantee that these accurately reflect
+	 * the error state of the resource. The primary parameter
+	 * to compute code actions is the provided range.
      *
      * @var Diagnostic[]
      */
     public $diagnostics;
+
+    /**
+	 * Requested kind of actions to return.
+	 *
+	 * Actions not of this kind are filtered out by the client before being
+	 * shown. So servers can omit computing them.
+     *
+     * @var string[]|null
+     * @see CodeActionKind
+	 */
+	public $only;
+
+	/**
+	 * The reason why code actions were requested.
+	 *
+	 * @since 3.17.0
+     *
+     * @var int|null
+     * @see CodeActionTriggerKind
+	 */
+	public $triggerKind;
 
     /**
      * @param Diagnostic[] $diagnostics

--- a/src/CodeActionDisabled.php
+++ b/src/CodeActionDisabled.php
@@ -9,6 +9,8 @@ class CodeActionDisabled
      * disabled.
      *
      * This is displayed in the code actions UI.
+     *
+     * @var string
      */
     public $reason;
 

--- a/src/CodeActionDisabled.php
+++ b/src/CodeActionDisabled.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class CodeActionDisabled
+{
+    /**
+     * Human readable description of why the code action is currently
+     * disabled.
+     *
+     * This is displayed in the code actions UI.
+     */
+    public $reason;
+
+    public function __construct(string $reason)
+    {
+        $this->reason = $reason;
+    }
+}

--- a/src/CodeActionKind.php
+++ b/src/CodeActionKind.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+/**
+ * A set of predefined code action kinds.
+ */
+abstract class CodeActionKind
+{
+/**
+	 * Empty kind.
+	 */
+	const EMPTY = '';
+
+	/**
+	 * Base kind for quickfix actions: 'quickfix'.
+	 */
+	const QUICK_FIX = 'quickfix';
+
+	/**
+	 * Base kind for refactoring actions: 'refactor'.
+	 */
+	const REFACTOR = 'refactor';
+
+	/**
+	 * Base kind for refactoring extraction actions: 'refactor.extract'.
+	 *
+	 * Example extract actions:
+	 *
+	 * - Extract method
+	 * - Extract function
+	 * - Extract variable
+	 * - Extract interface from class
+	 * - ...
+	 */
+	const REFACTOR_EXTRACT = 'refactor.extract';
+
+	/**
+	 * Base kind for refactoring inline actions: 'refactor.inline'.
+	 *
+	 * Example inline actions:
+	 *
+	 * - Inline function
+	 * - Inline variable
+	 * - Inline constant
+	 * - ...
+	 */
+	const REFACTOR_INLINE = 'refactor.inline';
+
+	/**
+	 * Base kind for refactoring rewrite actions: 'refactor.rewrite'.
+	 *
+	 * Example rewrite actions:
+	 *
+	 * - Convert JavaScript function to class
+	 * - Add or remove parameter
+	 * - Encapsulate field
+	 * - Make method static
+	 * - Move method to base class
+	 * - ...
+	 */
+	const REFACTOR_REWRITE = 'refactor.rewrite';
+
+	/**
+	 * Base kind for source actions: `source`.
+	 *
+	 * Source code actions apply to the entire file.
+	 */
+	const SOURCE = 'source';
+
+	/**
+	 * Base kind for an organize imports source action:
+	 * `source.organizeImports`.
+	 */
+	const SOURCE_ORGANIZE_IMPORTS = 'source.organizeImports';
+
+	/**
+	 * Base kind for a 'fix all' source action: `source.fixAll`.
+	 *
+	 * 'Fix all' actions automatically fix errors that have a clear fix that
+	 * do not require user input. They should not suppress errors or perform
+	 * unsafe fixes such as generating new types or classes.
+	 *
+	 * @since 3.17.0
+	 */
+	const SOURCE_FIX_ALL = 'source.fixAll';
+}

--- a/src/CodeActionKind.php
+++ b/src/CodeActionKind.php
@@ -8,80 +8,80 @@ namespace LanguageServerProtocol;
 abstract class CodeActionKind
 {
 /**
-	 * Empty kind.
-	 */
-	const EMPTY = '';
+     * Empty kind.
+     */
+    const EMPTY = '';
 
-	/**
-	 * Base kind for quickfix actions: 'quickfix'.
-	 */
-	const QUICK_FIX = 'quickfix';
+    /**
+     * Base kind for quickfix actions: 'quickfix'.
+     */
+    const QUICK_FIX = 'quickfix';
 
-	/**
-	 * Base kind for refactoring actions: 'refactor'.
-	 */
-	const REFACTOR = 'refactor';
+    /**
+     * Base kind for refactoring actions: 'refactor'.
+     */
+    const REFACTOR = 'refactor';
 
-	/**
-	 * Base kind for refactoring extraction actions: 'refactor.extract'.
-	 *
-	 * Example extract actions:
-	 *
-	 * - Extract method
-	 * - Extract function
-	 * - Extract variable
-	 * - Extract interface from class
-	 * - ...
-	 */
-	const REFACTOR_EXTRACT = 'refactor.extract';
+    /**
+     * Base kind for refactoring extraction actions: 'refactor.extract'.
+     *
+     * Example extract actions:
+     *
+     * - Extract method
+     * - Extract function
+     * - Extract variable
+     * - Extract interface from class
+     * - ...
+     */
+    const REFACTOR_EXTRACT = 'refactor.extract';
 
-	/**
-	 * Base kind for refactoring inline actions: 'refactor.inline'.
-	 *
-	 * Example inline actions:
-	 *
-	 * - Inline function
-	 * - Inline variable
-	 * - Inline constant
-	 * - ...
-	 */
-	const REFACTOR_INLINE = 'refactor.inline';
+    /**
+     * Base kind for refactoring inline actions: 'refactor.inline'.
+     *
+     * Example inline actions:
+     *
+     * - Inline function
+     * - Inline variable
+     * - Inline constant
+     * - ...
+     */
+    const REFACTOR_INLINE = 'refactor.inline';
 
-	/**
-	 * Base kind for refactoring rewrite actions: 'refactor.rewrite'.
-	 *
-	 * Example rewrite actions:
-	 *
-	 * - Convert JavaScript function to class
-	 * - Add or remove parameter
-	 * - Encapsulate field
-	 * - Make method static
-	 * - Move method to base class
-	 * - ...
-	 */
-	const REFACTOR_REWRITE = 'refactor.rewrite';
+    /**
+     * Base kind for refactoring rewrite actions: 'refactor.rewrite'.
+     *
+     * Example rewrite actions:
+     *
+     * - Convert JavaScript function to class
+     * - Add or remove parameter
+     * - Encapsulate field
+     * - Make method static
+     * - Move method to base class
+     * - ...
+     */
+    const REFACTOR_REWRITE = 'refactor.rewrite';
 
-	/**
-	 * Base kind for source actions: `source`.
-	 *
-	 * Source code actions apply to the entire file.
-	 */
-	const SOURCE = 'source';
+    /**
+     * Base kind for source actions: `source`.
+     *
+     * Source code actions apply to the entire file.
+     */
+    const SOURCE = 'source';
 
-	/**
-	 * Base kind for an organize imports source action:
-	 * `source.organizeImports`.
-	 */
-	const SOURCE_ORGANIZE_IMPORTS = 'source.organizeImports';
+    /**
+     * Base kind for an organize imports source action:
+     * `source.organizeImports`.
+     */
+    const SOURCE_ORGANIZE_IMPORTS = 'source.organizeImports';
 
-	/**
-	 * Base kind for a 'fix all' source action: `source.fixAll`.
-	 *
-	 * 'Fix all' actions automatically fix errors that have a clear fix that
-	 * do not require user input. They should not suppress errors or perform
-	 * unsafe fixes such as generating new types or classes.
-	 *
-	 * @since 3.17.0
-	 */
-	const SOURCE_FIX_ALL = 'source.fixAll';
+    /**
+     * Base kind for a 'fix all' source action: `source.fixAll`.
+     *
+     * 'Fix all' actions automatically fix errors that have a clear fix that
+     * do not require user input. They should not suppress errors or perform
+     * unsafe fixes such as generating new types or classes.
+     *
+     * @since 3.17.0
+     */
+    const SOURCE_FIX_ALL = 'source.fixAll';
 }

--- a/src/CodeActionTriggerKind.php
+++ b/src/CodeActionTriggerKind.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+/**
+ * A set of predefined code action kinds.
+ */
+abstract class CodeActionTriggerKind
+{
+    /**
+     * Code actions were explicitly requested by the user or by an extension.
+     */
+    const INVOKED = 1;
+
+    /**
+     * Code actions were requested automatically.
+     *
+     * This typically happens when current selection in a file changes, but can
+     * also be triggered when file content changes.
+     */
+    const AUTOMATIC = 2;
+}

--- a/src/CodeDescription.php
+++ b/src/CodeDescription.php
@@ -10,9 +10,14 @@ namespace LanguageServerProtocol;
 class CodeDescription
 {
  /**
-	 * An URI to open with more information about the diagnostic error.
-	 *
-	 * @var string
-	 */
-	public $href;
+     * An URI to open with more information about the diagnostic error.
+     *
+     * @var string
+     */
+    public $href;
+
+    public function __construct(string $href)
+    {
+        $this->href = $href;
+    }
 }

--- a/src/CodeDescription.php
+++ b/src/CodeDescription.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+/**
+ * Structure to capture a description for an error code.
+ *
+ * @since 3.16.0
+ */
+class CodeDescription
+{
+ /**
+	 * An URI to open with more information about the diagnostic error.
+	 *
+	 * @var string
+	 */
+	public $href;
+}

--- a/src/CodeLens.php
+++ b/src/CodeLens.php
@@ -38,6 +38,7 @@ class CodeLens
      */
     public function __construct(Range $range = null, Command $command = null, $data = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->range = $range;
         $this->command = $command;
         $this->data = $data;

--- a/src/CodeLensClientCapabilities.php
+++ b/src/CodeLensClientCapabilities.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class CodeLensClientCapabilities
+{
+
+    /**
+     * Whether text document synchronization supports dynamic registration.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    public function __construct(
+        bool $dynamicRegistration = null
+    ){
+        $this->dynamicRegistration = $dynamicRegistration;
+    }
+}

--- a/src/CodeLensClientCapabilities.php
+++ b/src/CodeLensClientCapabilities.php
@@ -14,7 +14,7 @@ class CodeLensClientCapabilities
 
     public function __construct(
         bool $dynamicRegistration = null
-    ){
+    ) {
         $this->dynamicRegistration = $dynamicRegistration;
     }
 }

--- a/src/CodeLensWorkspaceClientCapabilities.php
+++ b/src/CodeLensWorkspaceClientCapabilities.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class CodeLensWorkspaceClientCapabilities
+{
+    /**
+     * Whether the client implementation supports a refresh request sent from the
+     * server to the client.
+     *
+     * Note that this event is global and will force the client to refresh all
+     * code lenses currently shown. It should be used with absolute care and is
+     * useful for situation where a server for example detect a project wide
+     * change that requires such a calculation.
+     *
+     * @var bool|null
+     */
+    public $refreshSupport;
+
+    public function __construct(
+        bool $refreshSupport = null
+    ) {
+        $this->refreshSupport = $refreshSupport;
+    }
+}

--- a/src/CompletionClientCapabilities.php
+++ b/src/CompletionClientCapabilities.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class CompletionClientCapabilities
+{
+
+    /**
+     * Whether completion supports dynamic registration.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    /**
+     * The client supports the following `CompletionItem` specific
+     * capabilities.
+     *
+     * @var CompletionClientCapabilitiesCompletionItem|null
+     */
+    public $completionItem;
+
+    /**
+     * The client supports to send additional context information for a
+     * `textDocument/completion` request.
+     *
+     * @var bool|null
+     */
+    public $contextSupport;
+
+    /**
+     * The client's default when the completion item doesn't provide a
+     * `insertTextMode` property.
+     *
+     * @since 3.17.0 - proposed state
+     *
+     * @var int|null
+     * @see InsertTextFormat
+     */
+    public $insertTextMode;
+
+    /**
+     * The client supports the following `CompletionList` specific
+     * capabilities.
+     *
+     * @since 3.17.0 - proposed state
+     *
+     * @var CompletionClientCapabilitiesCompletionList|null
+     */
+    public $completionList;
+
+    public function __construct(
+        bool $dynamicRegistration = null,
+        CompletionClientCapabilitiesCompletionItem $completionItem = null,
+        bool $contextSupport = null,
+        int $insertTextMode = null,
+        CompletionClientCapabilitiesCompletionList $completionList = null
+    ) {
+        $this->dynamicRegistration = $dynamicRegistration;
+        $this->completionItem = $completionItem;
+        $this->contextSupport = $contextSupport;
+        $this->insertTextMode = $insertTextMode;
+        $this->completionList = $completionList;
+    }
+}

--- a/src/CompletionClientCapabilitiesCompletionItem.php
+++ b/src/CompletionClientCapabilitiesCompletionItem.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class CompletionClientCapabilitiesCompletionItem
+{
+
+    /**
+     * Client supports snippets as insert text.
+     *
+     * A snippet can define tab stops and placeholders with `$1`, `$2`
+     * and `${3:foo}`. `$0` defines the final tab stop, it defaults to
+     * the end of the snippet. Placeholders with equal identifiers are
+     * linked, that is typing in one will update others too.
+     *
+     * @var bool|null
+     */
+    public $snippetSupport;
+
+    /**
+     * Client supports commit characters on a completion item.
+     *
+     * @var bool|null
+     */
+    public $commitCharactersSupport;
+
+    /**
+     * Client supports the follow content formats for the documentation
+     * property. The order describes the preferred format of the client.
+     *
+     * @var string[]|null
+     */
+    public $documentationFormat;
+
+    /**
+     * Client supports the deprecated property on a completion item.
+     *
+     * @var bool|null
+     */
+    public $deprecatedSupport;
+
+    /**
+     * Client supports the preselect property on a completion item.
+     *
+     * @var bool|null
+     */
+    public $preselectSupport;
+
+    /**
+     * Client supports the tag property on a completion item. Clients
+     * supporting tags have to handle unknown tags gracefully. Clients
+     * especially need to preserve unknown tags when sending a completion
+     * item back to the server in a resolve call.
+     *
+     * @since 3.15.0
+     *
+     * @var CompletionClientCapabilitiesCompletionItemTagSupport|null
+     */
+    public $tagSupport;
+
+    /**
+     * Client supports insert replace edit to control different behavior if
+     * a completion item is inserted in the text or should replace text.
+     *
+     * @since 3.16.0
+     *
+     * @var bool|null
+     */
+    public $insertReplaceSupport;
+
+    /**
+     * Indicates which properties a client can resolve lazily on a
+     * completion item. Before version 3.16.0 only the predefined properties
+     * `documentation` and `detail` could be resolved lazily.
+     *
+     * @since 3.16.0
+     *
+     * @var CompletionClientCapabilitiesCompletionItemResolveSupport|null
+     */
+    public $resolveSupport;
+
+    /**
+     * The client supports the `insertTextMode` property on
+     * a completion item to override the whitespace handling mode
+     * as defined by the client (see `insertTextMode`).
+     *
+     * @since 3.16.0
+     *
+     * @var CompletionClientCapabilitiesCompletionItemInsertTextModeSupport|null
+     */
+    public $insertTextModeSupport;
+
+    /**
+     * The client has support for completion item label
+     * details (see also `CompletionItemLabelDetails`).
+     *
+     * @since 3.17.0 - proposed state
+     *
+     * @var bool|null
+     */
+    public $labelDetailsSupport;
+
+    /**
+     * Undocumented function
+     *
+     * @param boolean|null $snippetSupport
+     * @param boolean|null $commitCharactersSupport
+     * @param string[]|null $documentationFormat
+     * @param boolean|null $deprecatedSupport
+     * @param boolean|null $preselectSupport
+     * @param CompletionClientCapabilitiesCompletionItemTagSupport|null $tagSupport
+     * @param boolean|null $insertReplaceSupport
+     * @param CompletionClientCapabilitiesCompletionItemResolveSupport|null $resolveSupport
+     * @param CompletionClientCapabilitiesCompletionItemInsertTextModeSupport|null $insertTextModeSupport
+     * @param boolean|null $labelDetailsSupport
+     */
+    public function __construct(
+        bool $snippetSupport = null,
+        bool $commitCharactersSupport = null,
+        array $documentationFormat = null,
+        bool $deprecatedSupport = null,
+        bool $preselectSupport = null,
+        CompletionClientCapabilitiesCompletionItemTagSupport $tagSupport = null,
+        bool $insertReplaceSupport = null,
+        CompletionClientCapabilitiesCompletionItemResolveSupport $resolveSupport = null,
+        CompletionClientCapabilitiesCompletionItemInsertTextModeSupport $insertTextModeSupport = null,
+        bool $labelDetailsSupport = null
+    ) {
+        $this->snippetSupport = $snippetSupport;
+        $this->commitCharactersSupport = $commitCharactersSupport;
+        $this->documentationFormat = $documentationFormat;
+        $this->deprecatedSupport = $deprecatedSupport;
+        $this->preselectSupport = $preselectSupport;
+        $this->tagSupport = $tagSupport;
+        $this->insertReplaceSupport = $insertReplaceSupport;
+        $this->resolveSupport = $resolveSupport;
+        $this->insertTextModeSupport = $insertTextModeSupport;
+        $this->labelDetailsSupport = $labelDetailsSupport;
+    }
+}

--- a/src/CompletionClientCapabilitiesCompletionItemInsertTextModeSupport.php
+++ b/src/CompletionClientCapabilitiesCompletionItemInsertTextModeSupport.php
@@ -16,7 +16,7 @@ class CompletionClientCapabilitiesCompletionItemInsertTextModeSupport
      * @param int[] $valueSet InsertTextMode
      */
     public function __construct(
-        array $valueSet = null
+        array $valueSet
     ) {
         $this->valueSet = $valueSet;
     }

--- a/src/CompletionClientCapabilitiesCompletionItemInsertTextModeSupport.php
+++ b/src/CompletionClientCapabilitiesCompletionItemInsertTextModeSupport.php
@@ -16,8 +16,9 @@ class CompletionClientCapabilitiesCompletionItemInsertTextModeSupport
      * @param int[] $valueSet InsertTextMode
      */
     public function __construct(
-        array $valueSet
+        array $valueSet = null
     ) {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->valueSet = $valueSet;
     }
 }

--- a/src/CompletionClientCapabilitiesCompletionItemInsertTextModeSupport.php
+++ b/src/CompletionClientCapabilitiesCompletionItemInsertTextModeSupport.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class CompletionClientCapabilitiesCompletionItemInsertTextModeSupport
+{
+
+    /**
+     * The tags supported by the client.
+     *
+     * @var int[]
+     */
+    public $valueSet;
+
+    /**
+     * @param int[] $valueSet InsertTextMode
+     */
+    public function __construct(
+        array $valueSet = null
+    ) {
+        $this->valueSet = $valueSet;
+    }
+}

--- a/src/CompletionClientCapabilitiesCompletionItemResolveSupport.php
+++ b/src/CompletionClientCapabilitiesCompletionItemResolveSupport.php
@@ -16,8 +16,9 @@ class CompletionClientCapabilitiesCompletionItemResolveSupport
      * @param string[] $properties
      */
     public function __construct(
-        array $properties
+        array $properties = null
     ) {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->properties = $properties;
     }
 }

--- a/src/CompletionClientCapabilitiesCompletionItemResolveSupport.php
+++ b/src/CompletionClientCapabilitiesCompletionItemResolveSupport.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class CompletionClientCapabilitiesCompletionItemResolveSupport
+{
+
+    /**
+     * The properties that a client can resolve lazily.
+     *
+     * @var string[]
+     */
+    public $properties;
+
+    /**
+     * @param string[] $properties
+     */
+    public function __construct(
+        array $properties
+    ) {
+        $this->properties = $properties;
+    }
+}

--- a/src/CompletionClientCapabilitiesCompletionItemTagSupport.php
+++ b/src/CompletionClientCapabilitiesCompletionItemTagSupport.php
@@ -16,7 +16,7 @@ class CompletionClientCapabilitiesCompletionItemTagSupport
      * @param int[] $valueSet CompletionItemTag
      */
     public function __construct(
-        array $valueSet = null
+        array $valueSet
     ) {
         $this->valueSet = $valueSet;
     }

--- a/src/CompletionClientCapabilitiesCompletionItemTagSupport.php
+++ b/src/CompletionClientCapabilitiesCompletionItemTagSupport.php
@@ -13,11 +13,12 @@ class CompletionClientCapabilitiesCompletionItemTagSupport
     public $valueSet;
 
     /**
-     * @param int[] $valueSet CompletionItemTag
+     * @param int[]|null $valueSet CompletionItemTag
      */
     public function __construct(
-        array $valueSet
+        array $valueSet = null
     ) {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->valueSet = $valueSet;
     }
 }

--- a/src/CompletionClientCapabilitiesCompletionItemTagSupport.php
+++ b/src/CompletionClientCapabilitiesCompletionItemTagSupport.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class CompletionClientCapabilitiesCompletionItemTagSupport
+{
+
+    /**
+     * The tags supported by the client.
+     *
+     * @var int[]
+     */
+    public $valueSet;
+
+    /**
+     * @param int[] $valueSet CompletionItemTag
+     */
+    public function __construct(
+        array $valueSet = null
+    ) {
+        $this->valueSet = $valueSet;
+    }
+}

--- a/src/CompletionClientCapabilitiesCompletionList.php
+++ b/src/CompletionClientCapabilitiesCompletionList.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class CompletionClientCapabilitiesCompletionList
+{
+
+    /**
+     * The client supports the the following itemDefaults on
+     * a completion list.
+     *
+     * The value lists the supported property names of the
+     * `CompletionList.itemDefaults` object. If omitted
+     * no properties are supported.
+     *
+     * @since 3.17.0 - proposed state
+     *
+     * @var string[]|null
+     */
+    public $itemDefaults;
+
+    /**
+     * @param string[]|null $itemDefaults
+     */
+    public function __construct(
+        array $itemDefaults = null
+    ) {
+        $this->itemDefaults = $itemDefaults;
+    }
+}

--- a/src/CompletionContext.php
+++ b/src/CompletionContext.php
@@ -24,6 +24,7 @@ class CompletionContext
 
     public function __construct(int $triggerKind = null, string $triggerCharacter = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->triggerKind = $triggerKind;
         $this->triggerCharacter = $triggerCharacter;
     }

--- a/src/CompletionItem.php
+++ b/src/CompletionItem.php
@@ -231,6 +231,7 @@ class CompletionItem
         $data = null,
         int $insertTextFormat = null
     ) {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->label = $label;
         $this->kind = $kind;
         $this->detail = $detail;

--- a/src/CompletionItem.php
+++ b/src/CompletionItem.php
@@ -15,13 +15,13 @@ class CompletionItem
     public $label;
 
     /**
-	 * Additional details for the label
-	 *
-	 * @since 3.17.0 - proposed state
+     * Additional details for the label
+     *
+     * @since 3.17.0 - proposed state
      *
      * @var CompletionItemLabelDetails|null
-	 */
-	public $labelDetails;
+     */
+    public $labelDetails;
 
     /**
      * The kind of this completion item. Based of the kind
@@ -33,13 +33,13 @@ class CompletionItem
     public $kind;
 
     /**
-	 * Tags for this completion item.
-	 *
-	 * @since 3.15.0
+     * Tags for this completion item.
+     *
+     * @since 3.15.0
      *
      * @var CompletionItemTag[]|null
-	 */
-	public $tags;
+     */
+    public $tags;
 
     /**
      * A human-readable string with additional information
@@ -56,25 +56,25 @@ class CompletionItem
      */
     public $documentation;
 
-	/**
-	 * Indicates if this item is deprecated.
-	 *
-	 * @deprecated Use `tags` instead if supported.
+    /**
+     * Indicates if this item is deprecated.
+     *
+     * @deprecated Use `tags` instead if supported.
      *
      * @var bool|null
-	 */
-	public $deprecated;
+     */
+    public $deprecated;
 
     /**
-	 * Select this item when showing.
-	 *
-	 * *Note* that only one completion item can be selected and that the
-	 * tool / client decides which item that is. The rule is that the *first*
-	 * item of those that match best is selected.
+     * Select this item when showing.
+     *
+     * *Note* that only one completion item can be selected and that the
+     * tool / client decides which item that is. The rule is that the *first*
+     * item of those that match best is selected.
      *
      * @var bool|null
-	 */
-	public $preselect;
+     */
+    public $preselect;
 
     /**
      * A string that should be used when comparing this item
@@ -93,98 +93,98 @@ class CompletionItem
     public $filterText;
 
     /**
-	 * A string that should be inserted into a document when selecting
-	 * this completion. When `falsy` the label is used as the insert text
-	 * for this item.
-	 *
-	 * The `insertText` is subject to interpretation by the client side.
-	 * Some tools might not take the string literally. For example
-	 * VS Code when code complete is requested in this example
-	 * `con<cursor position>` and a completion item with an `insertText` of
-	 * `console` is provided it will only insert `sole`. Therefore it is
-	 * recommended to use `textEdit` instead since it avoids additional client
-	 * side interpretation.
+     * A string that should be inserted into a document when selecting
+     * this completion. When `falsy` the label is used as the insert text
+     * for this item.
+     *
+     * The `insertText` is subject to interpretation by the client side.
+     * Some tools might not take the string literally. For example
+     * VS Code when code complete is requested in this example
+     * `con<cursor position>` and a completion item with an `insertText` of
+     * `console` is provided it will only insert `sole`. Therefore it is
+     * recommended to use `textEdit` instead since it avoids additional client
+     * side interpretation.
      *
      * @var string|null
      */
     public $insertText;
 
-	/**
-	 * The format of the insert text. The format applies to both the
-	 * `insertText` property and the `newText` property of a provided
-	 * `textEdit`. If omitted defaults to `InsertTextFormat.PlainText`.
-	 *
-	 * Please note that the insertTextFormat doesn't apply to
-	 * `additionalTextEdits`.
+    /**
+     * The format of the insert text. The format applies to both the
+     * `insertText` property and the `newText` property of a provided
+     * `textEdit`. If omitted defaults to `InsertTextFormat.PlainText`.
+     *
+     * Please note that the insertTextFormat doesn't apply to
+     * `additionalTextEdits`.
      *
      * @var int|null
      * @see InsertTextFormat
-	 */
-	public $insertTextFormat;
+     */
+    public $insertTextFormat;
 
-	/**
-	 * How whitespace and indentation is handled during completion
-	 * item insertion. If not provided the client's default value depends on
-	 * the `textDocument.completion.insertTextMode` client capability.
-	 *
-	 * @since 3.16.0
-	 * @since 3.17.0 - support for `textDocument.completion.insertTextMode`
+    /**
+     * How whitespace and indentation is handled during completion
+     * item insertion. If not provided the client's default value depends on
+     * the `textDocument.completion.insertTextMode` client capability.
+     *
+     * @since 3.16.0
+     * @since 3.17.0 - support for `textDocument.completion.insertTextMode`
      *
      * @var int|null
      * @see InsertTextMode
-	 */
-	public $insertTextMode;
+     */
+    public $insertTextMode;
 
     /**
-	 * An edit which is applied to a document when selecting this completion.
-	 * When an edit is provided the value of `insertText` is ignored.
-	 *
-	 * *Note:* The range of the edit must be a single line range and it must
-	 * contain the position at which completion has been requested.
-	 *
-	 * Most editors support two different operations when accepting a completion
-	 * item. One is to insert a completion text and the other is to replace an
-	 * existing text with a completion text. Since this can usually not be
-	 * predetermined by a server it can report both ranges. Clients need to
-	 * signal support for `InsertReplaceEdit`s via the
-	 * `textDocument.completion.completionItem.insertReplaceSupport` client
-	 * capability property.
-	 *
-	 * *Note 1:* The text edit's range as well as both ranges from an insert
-	 * replace edit must be a [single line] and they must contain the position
-	 * at which completion has been requested.
-	 * *Note 2:* If an `InsertReplaceEdit` is returned the edit's insert range
-	 * must be a prefix of the edit's replace range, that means it must be
-	 * contained and starting at the same position.
-	 *
-	 * @since 3.16.0 additional type `InsertReplaceEdit`
+     * An edit which is applied to a document when selecting this completion.
+     * When an edit is provided the value of `insertText` is ignored.
+     *
+     * *Note:* The range of the edit must be a single line range and it must
+     * contain the position at which completion has been requested.
+     *
+     * Most editors support two different operations when accepting a completion
+     * item. One is to insert a completion text and the other is to replace an
+     * existing text with a completion text. Since this can usually not be
+     * predetermined by a server it can report both ranges. Clients need to
+     * signal support for `InsertReplaceEdit`s via the
+     * `textDocument.completion.completionItem.insertReplaceSupport` client
+     * capability property.
+     *
+     * *Note 1:* The text edit's range as well as both ranges from an insert
+     * replace edit must be a [single line] and they must contain the position
+     * at which completion has been requested.
+     * *Note 2:* If an `InsertReplaceEdit` is returned the edit's insert range
+     * must be a prefix of the edit's replace range, that means it must be
+     * contained and starting at the same position.
+     *
+     * @since 3.16.0 additional type `InsertReplaceEdit`
      *
      * @var TextEdit|null
      */
     public $textEdit;
 
     /**
-	 * An optional array of additional text edits that are applied when
-	 * selecting this completion. Edits must not overlap (including the same
-	 * insert position) with the main edit nor with themselves.
-	 *
-	 * Additional text edits should be used to change text unrelated to the
-	 * current cursor position (for example adding an import statement at the
-	 * top of the file if the completion item will insert an unqualified type).
+     * An optional array of additional text edits that are applied when
+     * selecting this completion. Edits must not overlap (including the same
+     * insert position) with the main edit nor with themselves.
+     *
+     * Additional text edits should be used to change text unrelated to the
+     * current cursor position (for example adding an import statement at the
+     * top of the file if the completion item will insert an unqualified type).
      *
      * @var TextEdit[]|null
      */
     public $additionalTextEdits;
 
     /**
-	 * An optional set of characters that when pressed while this completion is
-	 * active will accept it first and then type that character. *Note* that all
-	 * commit characters should have `length=1` and that superfluous characters
-	 * will be ignored.
+     * An optional set of characters that when pressed while this completion is
+     * active will accept it first and then type that character. *Note* that all
+     * commit characters should have `length=1` and that superfluous characters
+     * will be ignored.
      *
      * @var string[]|null
-	 */
-	public $commitCharacters;
+     */
+    public $commitCharacters;
 
     /**
      * An optional command that is executed *after* inserting this completion. *Note* that

--- a/src/CompletionItem.php
+++ b/src/CompletionItem.php
@@ -15,12 +15,31 @@ class CompletionItem
     public $label;
 
     /**
+	 * Additional details for the label
+	 *
+	 * @since 3.17.0 - proposed state
+     *
+     * @var CompletionItemLabelDetails|null
+	 */
+	public $labelDetails;
+
+    /**
      * The kind of this completion item. Based of the kind
      * an icon is chosen by the editor.
      *
      * @var int|null
+     * @see CompletionItemKind
      */
     public $kind;
+
+    /**
+	 * Tags for this completion item.
+	 *
+	 * @since 3.15.0
+     *
+     * @var CompletionItemTag[]|null
+	 */
+	public $tags;
 
     /**
      * A human-readable string with additional information
@@ -36,6 +55,26 @@ class CompletionItem
      * @var string|null
      */
     public $documentation;
+
+	/**
+	 * Indicates if this item is deprecated.
+	 *
+	 * @deprecated Use `tags` instead if supported.
+     *
+     * @var bool|null
+	 */
+	public $deprecated;
+
+    /**
+	 * Select this item when showing.
+	 *
+	 * *Note* that only one completion item can be selected and that the
+	 * tool / client decides which item that is. The rule is that the *first*
+	 * item of those that match best is selected.
+     *
+     * @var bool|null
+	 */
+	public $preselect;
 
     /**
      * A string that should be used when comparing this item
@@ -54,30 +93,98 @@ class CompletionItem
     public $filterText;
 
     /**
-     * A string that should be inserted a document when selecting
-     * this completion. When `falsy` the label is used.
+	 * A string that should be inserted into a document when selecting
+	 * this completion. When `falsy` the label is used as the insert text
+	 * for this item.
+	 *
+	 * The `insertText` is subject to interpretation by the client side.
+	 * Some tools might not take the string literally. For example
+	 * VS Code when code complete is requested in this example
+	 * `con<cursor position>` and a completion item with an `insertText` of
+	 * `console` is provided it will only insert `sole`. Therefore it is
+	 * recommended to use `textEdit` instead since it avoids additional client
+	 * side interpretation.
      *
      * @var string|null
      */
     public $insertText;
 
+	/**
+	 * The format of the insert text. The format applies to both the
+	 * `insertText` property and the `newText` property of a provided
+	 * `textEdit`. If omitted defaults to `InsertTextFormat.PlainText`.
+	 *
+	 * Please note that the insertTextFormat doesn't apply to
+	 * `additionalTextEdits`.
+     *
+     * @var int|null
+     * @see InsertTextFormat
+	 */
+	public $insertTextFormat;
+
+	/**
+	 * How whitespace and indentation is handled during completion
+	 * item insertion. If not provided the client's default value depends on
+	 * the `textDocument.completion.insertTextMode` client capability.
+	 *
+	 * @since 3.16.0
+	 * @since 3.17.0 - support for `textDocument.completion.insertTextMode`
+     *
+     * @var int|null
+     * @see InsertTextMode
+	 */
+	public $insertTextMode;
+
     /**
-     * An edit which is applied to a document when selecting
-     * this completion. When an edit is provided the value of
-     * insertText is ignored.
+	 * An edit which is applied to a document when selecting this completion.
+	 * When an edit is provided the value of `insertText` is ignored.
+	 *
+	 * *Note:* The range of the edit must be a single line range and it must
+	 * contain the position at which completion has been requested.
+	 *
+	 * Most editors support two different operations when accepting a completion
+	 * item. One is to insert a completion text and the other is to replace an
+	 * existing text with a completion text. Since this can usually not be
+	 * predetermined by a server it can report both ranges. Clients need to
+	 * signal support for `InsertReplaceEdit`s via the
+	 * `textDocument.completion.completionItem.insertReplaceSupport` client
+	 * capability property.
+	 *
+	 * *Note 1:* The text edit's range as well as both ranges from an insert
+	 * replace edit must be a [single line] and they must contain the position
+	 * at which completion has been requested.
+	 * *Note 2:* If an `InsertReplaceEdit` is returned the edit's insert range
+	 * must be a prefix of the edit's replace range, that means it must be
+	 * contained and starting at the same position.
+	 *
+	 * @since 3.16.0 additional type `InsertReplaceEdit`
      *
      * @var TextEdit|null
      */
     public $textEdit;
 
     /**
-     * An optional array of additional text edits that are applied when
-     * selecting this completion. Edits must not overlap with the main edit
-     * nor with themselves.
+	 * An optional array of additional text edits that are applied when
+	 * selecting this completion. Edits must not overlap (including the same
+	 * insert position) with the main edit nor with themselves.
+	 *
+	 * Additional text edits should be used to change text unrelated to the
+	 * current cursor position (for example adding an import statement at the
+	 * top of the file if the completion item will insert an unqualified type).
      *
      * @var TextEdit[]|null
      */
     public $additionalTextEdits;
+
+    /**
+	 * An optional set of characters that when pressed while this completion is
+	 * active will accept it first and then type that character. *Note* that all
+	 * commit characters should have `length=1` and that superfluous characters
+	 * will be ignored.
+     *
+     * @var string[]|null
+	 */
+	public $commitCharacters;
 
     /**
      * An optional command that is executed *after* inserting this completion. *Note* that
@@ -95,15 +202,6 @@ class CompletionItem
      * @var mixed
      */
     public $data;
-
-    /**
-     * The format of the insert text. The format applies to both the `insertText` property
-     * and the `newText` property of a provided `textEdit`.
-     *
-     * @var int|null
-     * @see InsertTextFormat
-     */
-    public $insertTextFormat;
 
     /**
      * @param string          $label

--- a/src/CompletionItemLabelDetails.php
+++ b/src/CompletionItemLabelDetails.php
@@ -10,22 +10,22 @@ namespace LanguageServerProtocol;
 class CompletionItemLabelDetails
 {
     /**
-	 * An optional string which is rendered less prominently directly after
-	 * {@link CompletionItem.label label}, without any spacing. Should be
-	 * used for function signatures or type annotations.
-	 *
-	 * @var string|null
-	 */
-	public $detail;
+     * An optional string which is rendered less prominently directly after
+     * {@link CompletionItem.label label}, without any spacing. Should be
+     * used for function signatures or type annotations.
+     *
+     * @var string|null
+     */
+    public $detail;
 
-	/**
-	 * An optional string which is rendered less prominently after
-	 * {@link CompletionItemLabelDetails.detail}. Should be used for fully qualified
-	 * names or file path.
-	 *
-	 * @var string|null
-	 */
-	public $description;
+    /**
+     * An optional string which is rendered less prominently after
+     * {@link CompletionItemLabelDetails.detail}. Should be used for fully qualified
+     * names or file path.
+     *
+     * @var string|null
+     */
+    public $description;
 
     public function __construct(string $detail = null, string $description = null)
     {

--- a/src/CompletionItemLabelDetails.php
+++ b/src/CompletionItemLabelDetails.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+/**
+ * Additional details for a completion item label.
+ *
+ * @since 3.17.0 - proposed state
+ */
+class CompletionItemLabelDetails
+{
+    /**
+	 * An optional string which is rendered less prominently directly after
+	 * {@link CompletionItem.label label}, without any spacing. Should be
+	 * used for function signatures or type annotations.
+	 *
+	 * @var string|null
+	 */
+	public $detail;
+
+	/**
+	 * An optional string which is rendered less prominently after
+	 * {@link CompletionItemLabelDetails.detail}. Should be used for fully qualified
+	 * names or file path.
+	 *
+	 * @var string|null
+	 */
+	public $description;
+
+    public function __construct(string $detail = null, string $description = null)
+    {
+        $this->detail = $detail;
+        $this->description = $description;
+    }
+}

--- a/src/CompletionItemTag.php
+++ b/src/CompletionItemTag.php
@@ -7,5 +7,5 @@ abstract class CompletionItemTag
     /**
      * Render a completion as obsolete, usually using a strike-out.
      */
-    const Deprecated = 1;
+    const DEPRECATED = 1;
 }

--- a/src/CompletionItemTag.php
+++ b/src/CompletionItemTag.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+abstract class CompletionItemTag
+{
+    /**
+     * Render a completion as obsolete, usually using a strike-out.
+     */
+    const Deprecated = 1;
+}

--- a/src/CompletionList.php
+++ b/src/CompletionList.php
@@ -9,11 +9,11 @@ namespace LanguageServerProtocol;
 class CompletionList
 {
     /**
-	 * This list is not complete. Further typing should result in recomputing
-	 * this list.
-	 *
-	 * Recomputed lists have all their items replaced (not appended) in the
-	 * incomplete completion sessions.
+     * This list is not complete. Further typing should result in recomputing
+     * this list.
+     *
+     * Recomputed lists have all their items replaced (not appended) in the
+     * incomplete completion sessions.
      *
      * @var bool
      */
@@ -28,7 +28,8 @@ class CompletionList
 
     /**
      * @param CompletionItem[] $items        The completion items.
-     * @param bool             $isIncomplete This list it not complete. Further typing should result in recomputing this list.
+     * @param bool             $isIncomplete This list it not complete.
+     *                                       Further typing should result in recomputing this list.
      */
     public function __construct(array $items = [], bool $isIncomplete = false)
     {

--- a/src/CompletionList.php
+++ b/src/CompletionList.php
@@ -9,8 +9,11 @@ namespace LanguageServerProtocol;
 class CompletionList
 {
     /**
-     * This list it not complete. Further typing should result in recomputing this
-     * list.
+	 * This list is not complete. Further typing should result in recomputing
+	 * this list.
+	 *
+	 * Recomputed lists have all their items replaced (not appended) in the
+	 * incomplete completion sessions.
      *
      * @var bool
      */

--- a/src/ContentChangeEvent.php
+++ b/src/ContentChangeEvent.php
@@ -33,6 +33,7 @@ class ContentChangeEvent
     {
         $this->range = $range;
         $this->rangeLength = $rangeLength;
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->text = $text;
     }
 }

--- a/src/DeclarationClientCapabilities.php
+++ b/src/DeclarationClientCapabilities.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class DeclarationClientCapabilities
+{
+
+    /**
+     * Whether declaration supports dynamic registration. If this is set to
+     * `true` the client supports the new `DeclarationRegistrationOptions`
+     * return value for the corresponding server capability as well.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    /**
+     * The client supports additional metadata in the form of declaration links.
+     *
+     * @var bool|null
+     */
+    public $linkSupport;
+
+    public function __construct(
+        bool $dynamicRegistration = null,
+        bool $linkSupport = null
+    ) {
+        $this->dynamicRegistration = $dynamicRegistration;
+        $this->linkSupport = $linkSupport;
+    }
+}

--- a/src/DefinitionClientCapabilities.php
+++ b/src/DefinitionClientCapabilities.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class DefinitionClientCapabilities
+{
+
+    /**
+     * Whether definition supports dynamic registration.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    /**
+     * The client supports additional metadata in the form of definition links.
+     *
+     * @since 3.14.0
+     *
+     * @var bool|null
+     */
+    public $linkSupport;
+
+    public function __construct(bool $dynamicRegistration = null, bool $linkSupport = null)
+    {
+        $this->dynamicRegistration = $dynamicRegistration;
+        $this->linkSupport = $linkSupport;
+    }
+}

--- a/src/Diagnostic.php
+++ b/src/Diagnostic.php
@@ -26,7 +26,7 @@ class Diagnostic
     /**
      * The diagnostic's code. which might appear in the user interface
      *
-     * @var mixed|null
+     * @var int|null
      */
     public $code;
 
@@ -68,8 +68,7 @@ class Diagnostic
      * An array of related diagnostic information, e.g. when symbol-names within
      * a scope collide all definitions can be marked via this property.
      *
-     * @var array[]|null
-     * @see DiagnosticRelatedInformation
+     * @var DiagnosticRelatedInformation[]|null
      */
     public $relatedInformation;
 
@@ -91,12 +90,12 @@ class Diagnostic
      * @param  int    $severity DiagnosticSeverity
      * @param  string $source   A human-readable string describing the source of this diagnostic
      * @param  CodeDescription $codeDescription
-     * @param  array  $tags     Additional metadata about the diagnostic
-     * @param  array  $relatedInformation Related diagnostic information
+     * @param  int[]|null  $tags     Additional metadata about the diagnostic
+     * @param  DiagnosticRelatedInformation[]|null  $relatedInformation Related diagnostic information
      * @param  mixed  $data     A data entry field that is preserved between a `textDocument/publishDiagnostics` notification and `textDocument/codeAction` request
      */
     public function __construct(
-        string $message = null,
+        string $message,
         Range $range,
         int $code = null,
         int $severity = null,
@@ -111,5 +110,9 @@ class Diagnostic
         $this->code = $code;
         $this->severity = $severity;
         $this->source = $source;
+        $this->codeDescription = $codeDescription;
+        $this->tags = $tags;
+        $this->relatedInformation = $relatedInformation;
+        $this->data = $data;
     }
 }

--- a/src/Diagnostic.php
+++ b/src/Diagnostic.php
@@ -24,11 +24,20 @@ class Diagnostic
     public $severity;
 
     /**
-     * The diagnostic's code. Can be omitted.
+     * The diagnostic's code. which might appear in the user interface
      *
-     * @var int|string|null
+     * @var mixed|null
      */
     public $code;
+
+    /**
+     * An optional property to describe the error code.
+     *
+     * @since 3.16.0
+     *
+     * @var CodeDescription|null
+     */
+    public $codeDescription;
 
     /**
      * A human-readable string describing the source of this
@@ -46,14 +55,57 @@ class Diagnostic
     public $message;
 
     /**
+     * Additional metadata about the diagnostic.
+     *
+     * @since 3.15.0
+     *
+     * @var int[]|null
+     * @see DiagnosticTag
+     */
+    public $tags;
+
+    /**
+     * An array of related diagnostic information, e.g. when symbol-names within
+     * a scope collide all definitions can be marked via this property.
+     *
+     * @var array[]|null
+     * @see DiagnosticRelatedInformation
+     */
+    public $relatedInformation;
+
+    /**
+     * A data entry field that is preserved between a
+     * `textDocument/publishDiagnostics` notification and
+     * `textDocument/codeAction` request.
+     *
+     * @since 3.16.0
+     *
+     * @var mixed|null
+     */
+    public $data;
+
+    /**
      * @param  string $message  The diagnostic's message
      * @param  Range  $range    The range at which the message applies
      * @param  int    $code     The diagnostic's code
      * @param  int    $severity DiagnosticSeverity
      * @param  string $source   A human-readable string describing the source of this diagnostic
+     * @param  CodeDescription $codeDescription
+     * @param  array  $tags     Additional metadata about the diagnostic
+     * @param  array  $relatedInformation Related diagnostic information
+     * @param  mixed  $data     A data entry field that is preserved between a `textDocument/publishDiagnostics` notification and `textDocument/codeAction` request
      */
-    public function __construct(string $message = null, Range $range, int $code = null, int $severity = null, string $source = null)
-    {
+    public function __construct(
+        string $message = null,
+        Range $range,
+        int $code = null,
+        int $severity = null,
+        string $source = null,
+        CodeDescription $codeDescription = null,
+        array $tags = null,
+        array $relatedInformation = null,
+        $data = null
+    ) {
         $this->message = $message;
         $this->range = $range;
         $this->code = $code;

--- a/src/Diagnostic.php
+++ b/src/Diagnostic.php
@@ -84,19 +84,20 @@ class Diagnostic
     public $data;
 
     /**
-     * @param  string $message  The diagnostic's message
-     * @param  Range  $range    The range at which the message applies
-     * @param  int    $code     The diagnostic's code
-     * @param  int    $severity DiagnosticSeverity
-     * @param  string $source   A human-readable string describing the source of this diagnostic
-     * @param  CodeDescription $codeDescription
+     * @param  string|null $message  The diagnostic's message
+     * @param  Range|null  $range    The range at which the message applies
+     * @param  int|null    $code     The diagnostic's code
+     * @param  int|null    $severity DiagnosticSeverity
+     * @param  string|null $source   A human-readable string describing the source of this diagnostic
+     * @param  CodeDescription|null $codeDescription
      * @param  int[]|null  $tags     Additional metadata about the diagnostic
      * @param  DiagnosticRelatedInformation[]|null  $relatedInformation Related diagnostic information
-     * @param  mixed  $data     A data entry field that is preserved between a `textDocument/publishDiagnostics` notification and `textDocument/codeAction` request
+     * @param  mixed  $data     A data entry field that is preserved between a `textDocument/publishDiagnostics`
+     *                          notification and `textDocument/codeAction` request
      */
     public function __construct(
-        string $message,
-        Range $range,
+        string $message = null,
+        Range $range = null,
         int $code = null,
         int $severity = null,
         string $source = null,
@@ -105,7 +106,9 @@ class Diagnostic
         array $relatedInformation = null,
         $data = null
     ) {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->message = $message;
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->range = $range;
         $this->code = $code;
         $this->severity = $severity;

--- a/src/DiagnosticRelatedInformation.php
+++ b/src/DiagnosticRelatedInformation.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+/**
+ * Represents a related message and source code location for a diagnostic.
+ * This should be used to point to code locations that cause or are related to
+ * a diagnostics, e.g when duplicating a symbol in a scope.
+ */
+class DiagnosticRelatedInformation
+{
+    /**
+     * The location of this related diagnostic information.
+     *
+     * @var Location
+     */
+    public $location;
+
+    /**
+     * The message of this related diagnostic information.
+     *
+     * @var string
+     */
+    public $message;
+
+    public function __construct(Location $location, string $message)
+    {
+        $this->location = $location;
+        $this->message = $message;
+    }
+}

--- a/src/DiagnosticTag.php
+++ b/src/DiagnosticTag.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+/**
+ * How whitespace and indentation is handled during completion
+ * item insertion.
+ *
+ * @since 3.16.0
+ */
+abstract class DiagnosticTag
+{
+    /**
+     * Unused or unnecessary code.
+     *
+     * Clients are allowed to render diagnostics with this tag faded out
+     * instead of having an error squiggle.
+     */
+    const UNNECESSARY = 1;
+
+    /**
+     * Deprecated or obsolete code.
+     *
+     * Clients are allowed to rendered diagnostics with this tag strike through.
+     */
+    const DEPRECATED = 2;
+}

--- a/src/DidChangeConfigurationClientCapabilities.php
+++ b/src/DidChangeConfigurationClientCapabilities.php
@@ -14,7 +14,7 @@ class DidChangeConfigurationClientCapabilities
 
     public function __construct(
         bool $dynamicRegistration = null
-    ){
+    ) {
         $this->dynamicRegistration = $dynamicRegistration;
     }
 }

--- a/src/DidChangeConfigurationClientCapabilities.php
+++ b/src/DidChangeConfigurationClientCapabilities.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class DidChangeConfigurationClientCapabilities
+{
+
+    /**
+     * Did change configuration notification supports dynamic registration.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    public function __construct(
+        bool $dynamicRegistration = null
+    ){
+        $this->dynamicRegistration = $dynamicRegistration;
+    }
+}

--- a/src/DidChangeWatchedFilesClientCapabilities.php
+++ b/src/DidChangeWatchedFilesClientCapabilities.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class DidChangeWatchedFilesClientCapabilities
+{
+    /**
+     * Did change watched files notification supports dynamic registration.
+     * Please note that the current protocol doesn't support static
+     * configuration for file changes from the server side.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    public function __construct(
+        bool $dynamicRegistration = null
+    ){
+        $this->dynamicRegistration = $dynamicRegistration;
+    }
+}

--- a/src/DidChangeWatchedFilesClientCapabilities.php
+++ b/src/DidChangeWatchedFilesClientCapabilities.php
@@ -15,7 +15,7 @@ class DidChangeWatchedFilesClientCapabilities
 
     public function __construct(
         bool $dynamicRegistration = null
-    ){
+    ) {
         $this->dynamicRegistration = $dynamicRegistration;
     }
 }

--- a/src/DocumentColorClientCapabilities.php
+++ b/src/DocumentColorClientCapabilities.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class DocumentColorClientCapabilities
+{
+
+    /**
+     * Whether text document synchronization supports dynamic registration.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    public function __construct(
+        bool $dynamicRegistration = null
+    ){
+        $this->dynamicRegistration = $dynamicRegistration;
+    }
+}

--- a/src/DocumentColorClientCapabilities.php
+++ b/src/DocumentColorClientCapabilities.php
@@ -14,7 +14,7 @@ class DocumentColorClientCapabilities
 
     public function __construct(
         bool $dynamicRegistration = null
-    ){
+    ) {
         $this->dynamicRegistration = $dynamicRegistration;
     }
 }

--- a/src/DocumentFormattingClientCapabilities.php
+++ b/src/DocumentFormattingClientCapabilities.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class DocumentFormattingClientCapabilities
+{
+
+    /**
+     * Whether text document synchronization supports dynamic registration.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    public function __construct(
+        bool $dynamicRegistration = null
+    ){
+        $this->dynamicRegistration = $dynamicRegistration;
+    }
+}

--- a/src/DocumentFormattingClientCapabilities.php
+++ b/src/DocumentFormattingClientCapabilities.php
@@ -14,7 +14,7 @@ class DocumentFormattingClientCapabilities
 
     public function __construct(
         bool $dynamicRegistration = null
-    ){
+    ) {
         $this->dynamicRegistration = $dynamicRegistration;
     }
 }

--- a/src/DocumentHighlight.php
+++ b/src/DocumentHighlight.php
@@ -25,6 +25,7 @@ class DocumentHighlight
 
     public function __construct(Range $range = null, int $kind = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->range = $range;
         $this->kind = $kind;
     }

--- a/src/DocumentHighlightClientCapabilities.php
+++ b/src/DocumentHighlightClientCapabilities.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class DocumentHighlightClientCapabilities
+{
+    /**
+     * Whether references supports dynamic registration.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    public function __construct(bool $dynamicRegistration = null)
+    {
+        $this->dynamicRegistration = $dynamicRegistration;
+    }
+}

--- a/src/DocumentLinkClientCapabilities.php
+++ b/src/DocumentLinkClientCapabilities.php
@@ -13,18 +13,18 @@ class DocumentLinkClientCapabilities
     public $dynamicRegistration;
 
     /**
-	 * Whether the client supports the `tooltip` property on `DocumentLink`.
-	 *
-	 * @since 3.15.0
+     * Whether the client supports the `tooltip` property on `DocumentLink`.
+     *
+     * @since 3.15.0
      *
      * @var bool|null
-	 */
-	public $tooltipSupport;
+     */
+    public $tooltipSupport;
 
     public function __construct(
         bool $dynamicRegistration = null,
         bool $tooltipSupport = null
-    ){
+    ) {
         $this->dynamicRegistration = $dynamicRegistration;
         $this->tooltipSupport = $tooltipSupport;
     }

--- a/src/DocumentLinkClientCapabilities.php
+++ b/src/DocumentLinkClientCapabilities.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class DocumentLinkClientCapabilities
+{
+
+    /**
+     * Whether text document synchronization supports dynamic registration.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    /**
+	 * Whether the client supports the `tooltip` property on `DocumentLink`.
+	 *
+	 * @since 3.15.0
+     *
+     * @var bool|null
+	 */
+	public $tooltipSupport;
+
+    public function __construct(
+        bool $dynamicRegistration = null,
+        bool $tooltipSupport = null
+    ){
+        $this->dynamicRegistration = $dynamicRegistration;
+        $this->tooltipSupport = $tooltipSupport;
+    }
+}

--- a/src/DocumentOnTypeFormattingClientCapabilities.php
+++ b/src/DocumentOnTypeFormattingClientCapabilities.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class DocumentOnTypeFormattingClientCapabilities
+{
+
+    /**
+     * Whether text document synchronization supports dynamic registration.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    public function __construct(
+        bool $dynamicRegistration = null
+    ){
+        $this->dynamicRegistration = $dynamicRegistration;
+    }
+}

--- a/src/DocumentOnTypeFormattingClientCapabilities.php
+++ b/src/DocumentOnTypeFormattingClientCapabilities.php
@@ -14,7 +14,7 @@ class DocumentOnTypeFormattingClientCapabilities
 
     public function __construct(
         bool $dynamicRegistration = null
-    ){
+    ) {
         $this->dynamicRegistration = $dynamicRegistration;
     }
 }

--- a/src/DocumentOnTypeFormattingOptions.php
+++ b/src/DocumentOnTypeFormattingOptions.php
@@ -26,6 +26,7 @@ class DocumentOnTypeFormattingOptions
      */
     public function __construct(string $firstTriggerCharacter = null, array $moreTriggerCharacter = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->firstTriggerCharacter = $firstTriggerCharacter;
         $this->moreTriggerCharacter = $moreTriggerCharacter;
     }

--- a/src/DocumentRangeFormattingClientCapabilities.php
+++ b/src/DocumentRangeFormattingClientCapabilities.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class DocumentRangeFormattingClientCapabilities
+{
+
+    /**
+     * Whether text document synchronization supports dynamic registration.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    public function __construct(
+        bool $dynamicRegistration = null
+    ){
+        $this->dynamicRegistration = $dynamicRegistration;
+    }
+}

--- a/src/DocumentRangeFormattingClientCapabilities.php
+++ b/src/DocumentRangeFormattingClientCapabilities.php
@@ -14,7 +14,7 @@ class DocumentRangeFormattingClientCapabilities
 
     public function __construct(
         bool $dynamicRegistration = null
-    ){
+    ) {
         $this->dynamicRegistration = $dynamicRegistration;
     }
 }

--- a/src/DocumentSymbolClientCapabilities.php
+++ b/src/DocumentSymbolClientCapabilities.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class DocumentSymbolClientCapabilities
+{
+
+    /**
+     * Whether document symbol supports dynamic registration.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+	/**
+	 * Specific capabilities for the `SymbolKind` in the
+	 * `textDocument/documentSymbol` request.
+	 *
+	 * @var DocumentSymbolClientCapabilitiesSymbolKind|null
+	 */
+	public $symbolKind;
+
+	/**
+	 * The client supports hierarchical document symbols.
+	 *
+	 * @var bool|null
+	 */
+	public $hierarchicalDocumentSymbolSupport;
+
+	/**
+	 * The client supports tags on `SymbolInformation`. Tags are supported on
+	 * `DocumentSymbol` if `hierarchicalDocumentSymbolSupport` is set to true.
+	 * Clients supporting tags have to handle unknown tags gracefully.
+	 *
+	 * @since 3.16.0
+	 *
+	 * @var DocumentSymbolClientCapabilitiesTagSupport|null
+	 */
+	public $tagSupport;
+
+	/**
+	 * The client supports an additional label presented in the UI when
+	 * registering a document symbol provider.
+	 *
+	 * @since 3.16.0
+	 *
+	 * @var bool|null
+	 */
+	public $labelSupport;
+
+	public function __construct(
+		bool $dynamicRegistration = null,
+		DocumentSymbolClientCapabilitiesSymbolKind $symbolKind = null,
+		bool $hierarchicalDocumentSymbolSupport = null,
+		DocumentSymbolClientCapabilitiesTagSupport $tagSupport = null,
+		bool $labelSupport = null
+	) {
+		$this->dynamicRegistration = $dynamicRegistration;
+		$this->symbolKind = $symbolKind;
+		$this->hierarchicalDocumentSymbolSupport = $hierarchicalDocumentSymbolSupport;
+		$this->tagSupport = $tagSupport;
+		$this->labelSupport = $labelSupport;
+	}
+}

--- a/src/DocumentSymbolClientCapabilities.php
+++ b/src/DocumentSymbolClientCapabilities.php
@@ -12,53 +12,53 @@ class DocumentSymbolClientCapabilities
      */
     public $dynamicRegistration;
 
-	/**
-	 * Specific capabilities for the `SymbolKind` in the
-	 * `textDocument/documentSymbol` request.
-	 *
-	 * @var DocumentSymbolClientCapabilitiesSymbolKind|null
-	 */
-	public $symbolKind;
+    /**
+     * Specific capabilities for the `SymbolKind` in the
+     * `textDocument/documentSymbol` request.
+     *
+     * @var DocumentSymbolClientCapabilitiesSymbolKind|null
+     */
+    public $symbolKind;
 
-	/**
-	 * The client supports hierarchical document symbols.
-	 *
-	 * @var bool|null
-	 */
-	public $hierarchicalDocumentSymbolSupport;
+    /**
+     * The client supports hierarchical document symbols.
+     *
+     * @var bool|null
+     */
+    public $hierarchicalDocumentSymbolSupport;
 
-	/**
-	 * The client supports tags on `SymbolInformation`. Tags are supported on
-	 * `DocumentSymbol` if `hierarchicalDocumentSymbolSupport` is set to true.
-	 * Clients supporting tags have to handle unknown tags gracefully.
-	 *
-	 * @since 3.16.0
-	 *
-	 * @var DocumentSymbolClientCapabilitiesTagSupport|null
-	 */
-	public $tagSupport;
+    /**
+     * The client supports tags on `SymbolInformation`. Tags are supported on
+     * `DocumentSymbol` if `hierarchicalDocumentSymbolSupport` is set to true.
+     * Clients supporting tags have to handle unknown tags gracefully.
+     *
+     * @since 3.16.0
+     *
+     * @var DocumentSymbolClientCapabilitiesTagSupport|null
+     */
+    public $tagSupport;
 
-	/**
-	 * The client supports an additional label presented in the UI when
-	 * registering a document symbol provider.
-	 *
-	 * @since 3.16.0
-	 *
-	 * @var bool|null
-	 */
-	public $labelSupport;
+    /**
+     * The client supports an additional label presented in the UI when
+     * registering a document symbol provider.
+     *
+     * @since 3.16.0
+     *
+     * @var bool|null
+     */
+    public $labelSupport;
 
-	public function __construct(
-		bool $dynamicRegistration = null,
-		DocumentSymbolClientCapabilitiesSymbolKind $symbolKind = null,
-		bool $hierarchicalDocumentSymbolSupport = null,
-		DocumentSymbolClientCapabilitiesTagSupport $tagSupport = null,
-		bool $labelSupport = null
-	) {
-		$this->dynamicRegistration = $dynamicRegistration;
-		$this->symbolKind = $symbolKind;
-		$this->hierarchicalDocumentSymbolSupport = $hierarchicalDocumentSymbolSupport;
-		$this->tagSupport = $tagSupport;
-		$this->labelSupport = $labelSupport;
-	}
+    public function __construct(
+        bool $dynamicRegistration = null,
+        DocumentSymbolClientCapabilitiesSymbolKind $symbolKind = null,
+        bool $hierarchicalDocumentSymbolSupport = null,
+        DocumentSymbolClientCapabilitiesTagSupport $tagSupport = null,
+        bool $labelSupport = null
+    ) {
+        $this->dynamicRegistration = $dynamicRegistration;
+        $this->symbolKind = $symbolKind;
+        $this->hierarchicalDocumentSymbolSupport = $hierarchicalDocumentSymbolSupport;
+        $this->tagSupport = $tagSupport;
+        $this->labelSupport = $labelSupport;
+    }
 }

--- a/src/DocumentSymbolClientCapabilitiesSymbolKind.php
+++ b/src/DocumentSymbolClientCapabilitiesSymbolKind.php
@@ -27,9 +27,9 @@ class DocumentSymbolClientCapabilitiesSymbolKind
     /**
      * Undocumented function
      *
-     * @param int[]|null $valueSet
+     * @param int[] $valueSet
      */
-    public function __construct(array $valueSet = null)
+    public function __construct(array $valueSet)
     {
         $this->valueSet = $valueSet;
     }

--- a/src/DocumentSymbolClientCapabilitiesSymbolKind.php
+++ b/src/DocumentSymbolClientCapabilitiesSymbolKind.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+/**
+ * Specific capabilities for the `SymbolKind` in the
+ * `textDocument/documentSymbol` request.
+ */
+class DocumentSymbolClientCapabilitiesSymbolKind
+{
+
+    /**
+     * The symbol kind values the client supports. When this
+     * property exists the client also guarantees that it will
+     * handle values outside its set gracefully and falls back
+     * to a default value when unknown.
+     *
+     * If this property is not present the client only supports
+     * the symbol kinds from `File` to `Array` as defined in
+     * the initial version of the protocol.
+     *
+     * @var int[]
+     * @see SymbolKind
+     */
+    public $valueSet;
+
+    /**
+     * Undocumented function
+     *
+     * @param int[]|null $valueSet
+     */
+    public function __construct(array $valueSet = null)
+    {
+        $this->valueSet = $valueSet;
+    }
+}

--- a/src/DocumentSymbolClientCapabilitiesSymbolKind.php
+++ b/src/DocumentSymbolClientCapabilitiesSymbolKind.php
@@ -27,10 +27,11 @@ class DocumentSymbolClientCapabilitiesSymbolKind
     /**
      * Undocumented function
      *
-     * @param int[] $valueSet
+     * @param int[]|null $valueSet
      */
-    public function __construct(array $valueSet)
+    public function __construct(array $valueSet = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->valueSet = $valueSet;
     }
 }

--- a/src/DocumentSymbolClientCapabilitiesTagSupport.php
+++ b/src/DocumentSymbolClientCapabilitiesTagSupport.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class DocumentSymbolClientCapabilitiesTagSupport
+{
+
+    /**
+     * The symbol kind values the client supports. When this
+     * property exists the client also guarantees that it will
+     * handle values outside its set gracefully and falls back
+     * to a default value when unknown.
+     *
+     * If this property is not present the client only supports
+     * the symbol kinds from `File` to `Array` as defined in
+     * the initial version of the protocol.
+     *
+     * @var int[]
+     */
+    public $valueSet;
+
+    /**
+     * Undocumented function
+     *
+     * @param SymbolTag[]|null $valueSet
+     */
+    public function __construct(array $valueSet = null)
+    {
+        $this->valueSet = $valueSet;
+    }
+}

--- a/src/DocumentSymbolClientCapabilitiesTagSupport.php
+++ b/src/DocumentSymbolClientCapabilitiesTagSupport.php
@@ -22,9 +22,9 @@ class DocumentSymbolClientCapabilitiesTagSupport
     /**
      * Undocumented function
      *
-     * @param SymbolTag[]|null $valueSet
+     * @param int[] $valueSet
      */
-    public function __construct(array $valueSet = null)
+    public function __construct(array $valueSet)
     {
         $this->valueSet = $valueSet;
     }

--- a/src/DocumentSymbolClientCapabilitiesTagSupport.php
+++ b/src/DocumentSymbolClientCapabilitiesTagSupport.php
@@ -22,10 +22,11 @@ class DocumentSymbolClientCapabilitiesTagSupport
     /**
      * Undocumented function
      *
-     * @param int[] $valueSet
+     * @param int[]|null $valueSet
      */
-    public function __construct(array $valueSet)
+    public function __construct(array $valueSet = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->valueSet = $valueSet;
     }
 }

--- a/src/ExecuteCommandClientCapabilities.php
+++ b/src/ExecuteCommandClientCapabilities.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class ExecuteCommandClientCapabilities
+{
+
+    /**
+     * Execute command supports dynamic registration.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    public function __construct(
+        bool $dynamicRegistration = null
+    ){
+        $this->dynamicRegistration = $dynamicRegistration;
+    }
+}

--- a/src/ExecuteCommandClientCapabilities.php
+++ b/src/ExecuteCommandClientCapabilities.php
@@ -14,7 +14,7 @@ class ExecuteCommandClientCapabilities
 
     public function __construct(
         bool $dynamicRegistration = null
-    ){
+    ) {
         $this->dynamicRegistration = $dynamicRegistration;
     }
 }

--- a/src/ExecuteCommandOptions.php
+++ b/src/ExecuteCommandOptions.php
@@ -17,7 +17,7 @@ class ExecuteCommandOptions
      */
     public function __construct(
         array $commands
-    ){
+    ) {
         $this->commands = $commands;
     }
 }

--- a/src/ExecuteCommandOptions.php
+++ b/src/ExecuteCommandOptions.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class ExecuteCommandOptions
+{
+
+    /**
+     * The commands to be executed on the server
+     *
+     * @var string[]
+     */
+    public $commands;
+
+    /**
+     * @param string[] $commands
+     */
+    public function __construct(
+        array $commands
+    ){
+        $this->commands = $commands;
+    }
+}

--- a/src/FailureHandlingKind.php
+++ b/src/FailureHandlingKind.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+/**
+ * Defines how the host (editor) should sync document changes to the language server.
+ */
+abstract class FailureHandlingKind
+{
+    /**
+     * Applying the workspace change is simply aborted if one of the changes
+     * provided fails. All operations executed before the failing operation
+     * stay executed.
+     */
+    const ABORT = 'abort';
+
+    /**
+     * All operations are executed transactional. That means they either all
+     * succeed or no changes at all are applied to the workspace.
+     */
+    const TRANSACTIONAL = 'transactional';
+
+
+    /**
+     * If the workspace edit contains only textual file changes they are
+     * executed transactional. If resource changes (create, rename or delete
+     * file) are part of the change the failure handling strategy is abort.
+     */
+    const TEXT_ONLY_TRANSACTIONAL = 'textOnlyTransactional';
+
+    /**
+     * The client tries to undo the operations already executed. But there is no
+     * guarantee that this is succeeding.
+     */
+    const UNDO = 'undo';
+}

--- a/src/FoldingRangeClientCapabilities.php
+++ b/src/FoldingRangeClientCapabilities.php
@@ -13,30 +13,30 @@ class FoldingRangeClientCapabilities
     public $dynamicRegistration;
 
     /**
-	 * The maximum number of folding ranges that the client prefers to receive
-	 * per document. The value serves as a hint, servers are free to follow the
-	 * limit.
-	 *
-	 * @var int|null
-	 */
-	public $rangeLimit;
+     * The maximum number of folding ranges that the client prefers to receive
+     * per document. The value serves as a hint, servers are free to follow the
+     * limit.
+     *
+     * @var int|null
+     */
+    public $rangeLimit;
 
-	/**
-	 * If set, the client signals that it only supports folding complete lines.
-	 * If set, client will ignore specified `startCharacter` and `endCharacter`
-	 * properties in a FoldingRange.
-	 *
-	 * @var bool|null
-	 */
-	public $lineFoldingOnly;
+    /**
+     * If set, the client signals that it only supports folding complete lines.
+     * If set, client will ignore specified `startCharacter` and `endCharacter`
+     * properties in a FoldingRange.
+     *
+     * @var bool|null
+     */
+    public $lineFoldingOnly;
 
     public function __construct(
-		bool $dynamicRegistration = null,
-		int $rangeLimit = null,
-		bool $lineFoldingOnly = null
-	) {
-		$this->dynamicRegistration = $dynamicRegistration;
-		$this->rangeLimit = $rangeLimit;
-		$this->lineFoldingOnly = $lineFoldingOnly;
-	}
+        bool $dynamicRegistration = null,
+        int $rangeLimit = null,
+        bool $lineFoldingOnly = null
+    ) {
+        $this->dynamicRegistration = $dynamicRegistration;
+        $this->rangeLimit = $rangeLimit;
+        $this->lineFoldingOnly = $lineFoldingOnly;
+    }
 }

--- a/src/FoldingRangeClientCapabilities.php
+++ b/src/FoldingRangeClientCapabilities.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class FoldingRangeClientCapabilities
+{
+
+    /**
+     * Whether hover supports dynamic registration.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    /**
+	 * The maximum number of folding ranges that the client prefers to receive
+	 * per document. The value serves as a hint, servers are free to follow the
+	 * limit.
+	 *
+	 * @var int|null
+	 */
+	public $rangeLimit;
+
+	/**
+	 * If set, the client signals that it only supports folding complete lines.
+	 * If set, client will ignore specified `startCharacter` and `endCharacter`
+	 * properties in a FoldingRange.
+	 *
+	 * @var bool|null
+	 */
+	public $lineFoldingOnly;
+
+    public function __construct(
+		bool $dynamicRegistration = null,
+		int $rangeLimit = null,
+		bool $lineFoldingOnly = null
+	) {
+		$this->dynamicRegistration = $dynamicRegistration;
+		$this->rangeLimit = $rangeLimit;
+		$this->lineFoldingOnly = $lineFoldingOnly;
+	}
+}

--- a/src/FormattingOptions.php
+++ b/src/FormattingOptions.php
@@ -25,7 +25,9 @@ class FormattingOptions
 
     public function __construct(int $tabSize = null, bool $insertSpaces = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->tabSize = $tabSize;
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->insertSpaces = $insertSpaces;
     }
 }

--- a/src/Hover.php
+++ b/src/Hover.php
@@ -27,6 +27,7 @@ class Hover
      */
     public function __construct($contents = null, $range = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->contents = $contents;
         $this->range = $range;
     }

--- a/src/HoverClientCapabilities.php
+++ b/src/HoverClientCapabilities.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class HoverClientCapabilities
+{
+
+    /**
+     * Whether hover supports dynamic registration.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    /**
+     * Client supports the follow content formats if the content
+     * property refers to a `literal of type MarkupContent`.
+     * The order describes the preferred format of the client.
+     *
+     * @var string[]|null
+     * @see MarkupKind
+     */
+    public $contentFormat;
+
+    /**
+     * @param boolean|null $dynamicRegistration
+     * @param string[]|null $contentFormat
+     */
+    public function __construct(
+        bool $dynamicRegistration = null,
+        array $contentFormat = null
+    ) {
+        $this->dynamicRegistration = $dynamicRegistration;
+        $this->contentFormat = $contentFormat;
+    }
+}

--- a/src/ImplementationClientCapabilities.php
+++ b/src/ImplementationClientCapabilities.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class ImplementationClientCapabilities
+{
+    /**
+     * Whether implementation supports dynamic registration. If this is set to
+     * `true` the client supports the new `ImplementationRegistrationOptions`
+     * return value for the corresponding server capability as well.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    /**
+     * The client supports additional metadata in the form of definition links.
+     *
+     * @since 3.14.0
+     *
+     * @var boolean|null
+     */
+    public $linkSupport;
+
+    public function __construct(
+        bool $dynamicRegistration = null,
+        bool $linkSupport = null
+    ) {
+        $this->dynamicRegistration = $dynamicRegistration;
+        $this->linkSupport = $linkSupport;
+    }
+
+}

--- a/src/ImplementationClientCapabilities.php
+++ b/src/ImplementationClientCapabilities.php
@@ -29,5 +29,4 @@ class ImplementationClientCapabilities
         $this->dynamicRegistration = $dynamicRegistration;
         $this->linkSupport = $linkSupport;
     }
-
 }

--- a/src/InitializeResult.php
+++ b/src/InitializeResult.php
@@ -12,19 +12,17 @@ class InitializeResult
     public $capabilities;
 
     /**
-	 * Information about the server.
-	 *
-	 * @since 3.15.0
+     * Information about the server.
+     *
+     * @since 3.15.0
      *
      * @var InitializeResultServerInfo|null
-	 */
-	public $serverInfo;
-
-    /**
-     * @param ServerCapabilities $capabilities
      */
-    public function __construct(ServerCapabilities $capabilities, InitializeResultServerInfo $serverInfo = null)
+    public $serverInfo;
+
+    public function __construct(ServerCapabilities $capabilities = null, InitializeResultServerInfo $serverInfo = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->capabilities = $capabilities;
         $this->serverInfo = $serverInfo;
     }

--- a/src/InitializeResult.php
+++ b/src/InitializeResult.php
@@ -12,10 +12,20 @@ class InitializeResult
     public $capabilities;
 
     /**
+	 * Information about the server.
+	 *
+	 * @since 3.15.0
+     *
+     * @var InitializeResultServerInfo|null
+	 */
+	public $serverInfo;
+
+    /**
      * @param ServerCapabilities $capabilities
      */
-    public function __construct(ServerCapabilities $capabilities = null)
+    public function __construct(ServerCapabilities $capabilities = null, InitializeResultServerInfo $serverInfo = null)
     {
-        $this->capabilities = $capabilities ?? new ServerCapabilities();
+        $this->capabilities = $capabilities;
+        $this->serverInfo = $serverInfo;
     }
 }

--- a/src/InitializeResult.php
+++ b/src/InitializeResult.php
@@ -23,7 +23,7 @@ class InitializeResult
     /**
      * @param ServerCapabilities $capabilities
      */
-    public function __construct(ServerCapabilities $capabilities = null, InitializeResultServerInfo $serverInfo = null)
+    public function __construct(ServerCapabilities $capabilities, InitializeResultServerInfo $serverInfo = null)
     {
         $this->capabilities = $capabilities;
         $this->serverInfo = $serverInfo;

--- a/src/InitializeResultServerInfo.php
+++ b/src/InitializeResultServerInfo.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class InitializeResultServerInfo
+{
+    /**
+     * The name of the server as defined by the server.
+     *
+     * @var string
+     */
+    public $name;
+
+    /**
+     * The server's version as defined by the server.
+     *
+     * @var string|null
+     */
+    public $version;
+
+    public function __construct(string $name, string $version = null)
+    {
+        $this->name = $name;
+        $this->version = $version;
+    }
+}

--- a/src/InsertTextFormat.php
+++ b/src/InsertTextFormat.php
@@ -6,7 +6,7 @@ namespace LanguageServerProtocol;
  * Defines whether the insert text in a completion item should be interpreted as
  * plain text or a snippet.
  */
-class InsertTextFormat
+abstract class InsertTextFormat
 {
     /**
      * The primary text to be inserted is treated as a plain string.

--- a/src/InsertTextMode.php
+++ b/src/InsertTextMode.php
@@ -11,22 +11,22 @@ namespace LanguageServerProtocol;
 abstract class InsertTextMode
 {
     /**
-	 * The insertion or replace strings is taken as it is. If the
-	 * value is multi line the lines below the cursor will be
-	 * inserted using the indentation defined in the string value.
-	 * The client will not apply any kind of adjustments to the
-	 * string.
-	 */
-	const AS_IS = 1;
+     * The insertion or replace strings is taken as it is. If the
+     * value is multi line the lines below the cursor will be
+     * inserted using the indentation defined in the string value.
+     * The client will not apply any kind of adjustments to the
+     * string.
+     */
+    const AS_IS = 1;
 
-	/**
-	 * The editor adjusts leading whitespace of new lines so that
-	 * they match the indentation up to the cursor of the line for
-	 * which the item is accepted.
-	 *
-	 * Consider a line like this: <2tabs><cursor><3tabs>foo. Accepting a
-	 * multi line completion item is indented using 2 tabs and all
-	 * following lines inserted will be indented using 2 tabs as well.
-	 */
-	const ADJUST_INDENTATION = 2;
+    /**
+     * The editor adjusts leading whitespace of new lines so that
+     * they match the indentation up to the cursor of the line for
+     * which the item is accepted.
+     *
+     * Consider a line like this: <2tabs><cursor><3tabs>foo. Accepting a
+     * multi line completion item is indented using 2 tabs and all
+     * following lines inserted will be indented using 2 tabs as well.
+     */
+    const ADJUST_INDENTATION = 2;
 }

--- a/src/InsertTextMode.php
+++ b/src/InsertTextMode.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+/**
+ * How whitespace and indentation is handled during completion
+ * item insertion.
+ *
+ * @since 3.16.0
+ */
+abstract class InsertTextMode
+{
+    /**
+	 * The insertion or replace strings is taken as it is. If the
+	 * value is multi line the lines below the cursor will be
+	 * inserted using the indentation defined in the string value.
+	 * The client will not apply any kind of adjustments to the
+	 * string.
+	 */
+	const AS_IS = 1;
+
+	/**
+	 * The editor adjusts leading whitespace of new lines so that
+	 * they match the indentation up to the cursor of the line for
+	 * which the item is accepted.
+	 *
+	 * Consider a line like this: <2tabs><cursor><3tabs>foo. Accepting a
+	 * multi line completion item is indented using 2 tabs and all
+	 * following lines inserted will be indented using 2 tabs as well.
+	 */
+	const ADJUST_INDENTATION = 2;
+}

--- a/src/LinkedEditingRangeClientCapabilities.php
+++ b/src/LinkedEditingRangeClientCapabilities.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class LinkedEditingRangeClientCapabilities
+{
+
+    /**
+     * Whether implementation supports dynamic registration.
+     * If this is set to `true` the client supports the new
+     * `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+     * return value for the corresponding server capability as well.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    public function __construct(
+        bool $dynamicRegistration = null
+    ){
+        $this->dynamicRegistration = $dynamicRegistration;
+    }
+}

--- a/src/LinkedEditingRangeClientCapabilities.php
+++ b/src/LinkedEditingRangeClientCapabilities.php
@@ -17,7 +17,7 @@ class LinkedEditingRangeClientCapabilities
 
     public function __construct(
         bool $dynamicRegistration = null
-    ){
+    ) {
         $this->dynamicRegistration = $dynamicRegistration;
     }
 }

--- a/src/Location.php
+++ b/src/Location.php
@@ -19,7 +19,9 @@ class Location
 
     public function __construct(string $uri = null, Range $range = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->uri = $uri;
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->range = $range;
     }
 }

--- a/src/LogMessage.php
+++ b/src/LogMessage.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+/**
+ * The log message notification is sent from the server to the client to ask the client to log a particular message.
+ */
+class LogMessage
+{
+    /**
+     * The message type. See {@link MessageType}
+     *
+     * @var int
+     * @see MessageType
+     */
+    public $type;
+
+    /**
+     * The actual message
+     *
+     * @var string
+     */
+    public $message;
+
+    public function __construct(int $type, string $message)
+    {
+        $this->type = $type;
+        $this->message = $message;
+    }
+}

--- a/src/LogTrace.php
+++ b/src/LogTrace.php
@@ -2,7 +2,6 @@
 
 namespace LanguageServerProtocol;
 
-
 /**
  * A notification to log the trace of the server’s execution.
  * The amount and content of these notifications depends on the

--- a/src/LogTrace.php
+++ b/src/LogTrace.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+
+/**
+ * A notification to log the trace of the server’s execution.
+ * The amount and content of these notifications depends on the
+ * current trace configuration. If trace is 'off', the server
+ * should not send any logTrace notification. If trace is
+ * 'messages', the server should not add the 'verbose' field in
+ * the LogTraceParams.
+ *
+ * $/logTrace should be used for systematic trace reporting.
+ * For single debugging messages, the server should send
+ * window/logMessage notifications.
+ */
+class LogTrace
+{
+    /**
+     * The message to be logged.
+     *
+     * @var string
+     */
+    public $message;
+
+    /**
+     * Additional information that can be computed if the `trace` configuration
+     * is set to `'verbose'`
+     *
+     * @var string|null
+     */
+    public $verbose;
+
+    public function __construct(string $message, string $verbose = null)
+    {
+        $this->message = $message;
+        $this->verbose = $verbose;
+    }
+}

--- a/src/MarkdownClientCapabilities.php
+++ b/src/MarkdownClientCapabilities.php
@@ -30,12 +30,12 @@ class MarkdownClientCapabilities
     public $allowedTags;
 
     /**
-     * @param string|null $parser
+     * @param string $parser
      * @param string|null $version
      * @param string[]|null $allowedTags
      */
     public function __construct(
-        string $parser = null,
+        string $parser,
         string $version = null,
         array $allowedTags = null
     ){

--- a/src/MarkdownClientCapabilities.php
+++ b/src/MarkdownClientCapabilities.php
@@ -30,15 +30,16 @@ class MarkdownClientCapabilities
     public $allowedTags;
 
     /**
-     * @param string $parser
+     * @param string|null $parser
      * @param string|null $version
      * @param string[]|null $allowedTags
      */
     public function __construct(
-        string $parser,
+        string $parser = null,
         string $version = null,
         array $allowedTags = null
-    ){
+    ) {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->parser = $parser;
         $this->version = $version;
         $this->allowedTags = $allowedTags;

--- a/src/MarkdownClientCapabilities.php
+++ b/src/MarkdownClientCapabilities.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class MarkdownClientCapabilities
+{
+
+    /**
+     * The name of the parser.
+     *
+     * @var string
+     */
+    public $parser;
+
+    /**
+     * The version of the parser.
+     *
+     * @var string|null
+     */
+    public $version;
+
+    /**
+     * A list of HTML tags that the client allows / supports in
+     * Markdown.
+     *
+     * @since 3.17.0
+     *
+     * @var string[]|null
+     */
+    public $allowedTags;
+
+    /**
+     * @param string|null $parser
+     * @param string|null $version
+     * @param string[]|null $allowedTags
+     */
+    public function __construct(
+        string $parser = null,
+        string $version = null,
+        array $allowedTags = null
+    ){
+        $this->parser = $parser;
+        $this->version = $version;
+        $this->allowedTags = $allowedTags;
+    }
+}

--- a/src/MarkedString.php
+++ b/src/MarkedString.php
@@ -16,7 +16,9 @@ class MarkedString
 
     public function __construct(string $language = null, string $value = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->language = $language;
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->value = $value;
     }
 }

--- a/src/MarkupContent.php
+++ b/src/MarkupContent.php
@@ -44,7 +44,9 @@ class MarkupContent
      */
     public function __construct(string $kind = null, string $value = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->kind = $kind;
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->value = $value;
     }
 }

--- a/src/MessageActionItem.php
+++ b/src/MessageActionItem.php
@@ -13,6 +13,7 @@ class MessageActionItem
 
     public function __construct(string $title = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->title = $title;
     }
 }

--- a/src/MonikerClientCapabilities.php
+++ b/src/MonikerClientCapabilities.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class MonikerClientCapabilities
+{
+
+    /**
+     * Whether implementation supports dynamic registration. If this is set to
+     * `true` the client supports the new `(TextDocumentRegistrationOptions &
+     * StaticRegistrationOptions)` return value for the corresponding server
+     * capability as well.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    public function __construct(
+        bool $dynamicRegistration = null
+    ) {
+        $this->dynamicRegistration = $dynamicRegistration;
+    }
+}

--- a/src/PackageDescriptor.php
+++ b/src/PackageDescriptor.php
@@ -20,6 +20,7 @@ class PackageDescriptor
      */
     public function __construct(string $name = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->name = $name;
     }
 }

--- a/src/ParameterInformation.php
+++ b/src/ParameterInformation.php
@@ -26,7 +26,7 @@ class ParameterInformation
      * The human-readable doc-comment of this signature. Will be shown
      * in the UI but can be omitted.
      *
-     * @var string|null
+     * @var MarkupContent|string|null
      */
     public $documentation;
 
@@ -34,10 +34,10 @@ class ParameterInformation
      * Create ParameterInformation
      *
      * @param string|int[] $label   The label of this parameter information.
-     * @param string $documentation The human-readable doc-comment of this signature. Will be shown in the UI but can
+     * @param MarkupContent|string|null $documentation The human-readable doc-comment of this signature. Will be shown in the UI but can
      *                              be omitted.
      */
-    public function __construct($label, string $documentation = null)
+    public function __construct($label, $documentation = null)
     {
         $this->label = $label;
         $this->documentation = $documentation;

--- a/src/ParameterInformation.php
+++ b/src/ParameterInformation.php
@@ -34,8 +34,8 @@ class ParameterInformation
      * Create ParameterInformation
      *
      * @param string|int[] $label   The label of this parameter information.
-     * @param MarkupContent|string|null $documentation The human-readable doc-comment of this signature. Will be shown in the UI but can
-     *                              be omitted.
+     * @param MarkupContent|string|null $documentation The human-readable doc-comment of this signature.
+     *                                  Will be shown in the UI but can be omitted.
      */
     public function __construct($label, $documentation = null)
     {

--- a/src/Position.php
+++ b/src/Position.php
@@ -60,6 +60,6 @@ class Position
     {
         $lines = explode("\n", $content);
         $slice = array_slice($lines, 0, $this->line);
-        return (int) array_sum(array_map('strlen', $slice)) + count($slice) + $this->character;
+        return array_sum(array_map('strlen', $slice)) + count($slice) + $this->character;
     }
 }

--- a/src/Position.php
+++ b/src/Position.php
@@ -23,7 +23,9 @@ class Position
 
     public function __construct(int $line = null, int $character = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->line = $line;
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->character = $character;
     }
 

--- a/src/PrepareSupportDefaultBehavior.php
+++ b/src/PrepareSupportDefaultBehavior.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+abstract class PrepareSupportDefaultBehavior
+{
+    /**
+     * The client's default behavior is to select the identifier
+     * according the to language's syntax rule.
+     */
+    const IDENTIFIER = 1;
+}

--- a/src/PublishDiagnosticsClientCapabilities.php
+++ b/src/PublishDiagnosticsClientCapabilities.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class PublishDiagnosticsClientCapabilities
+{
+/**
+     * Whether the clients accepts diagnostics with related information.
+     *
+     * @var bool|null
+     */
+    public $relatedInformation;
+
+    /**
+     * Client supports the tag property to provide meta data about a diagnostic.
+     * Clients supporting tags have to handle unknown tags gracefully.
+     *
+     * @since 3.15.0
+     *
+     * @var PublishDiagnosticsClientCapabilitiesTagSupport|null
+     */
+    public $tagSupport;
+
+    /**
+     * Whether the client interprets the version property of the
+     * `textDocument/publishDiagnostics` notification's parameter.
+     *
+     * @since 3.15.0
+     *
+     * @var bool|null
+     */
+    public $versionSupport;
+
+    /**
+     * Client supports a codeDescription property
+     *
+     * @since 3.16.0
+     *
+     * @var bool|null
+     */
+    public $codeDescriptionSupport;
+
+    /**
+     * Whether code action supports the `data` property which is
+     * preserved between a `textDocument/publishDiagnostics` and
+     * `textDocument/codeAction` request.
+     *
+     * @since 3.16.0
+     *
+     * @var bool|null
+     */
+    public $dataSupport;
+
+    public function __construct(
+        bool $relatedInformation = null,
+        PublishDiagnosticsClientCapabilitiesTagSupport $tagSupport = null,
+        bool $versionSupport = null,
+        bool $codeDescriptionSupport = null,
+        bool $dataSupport = null
+    ) {
+        $this->relatedInformation = $relatedInformation;
+        $this->tagSupport = $tagSupport;
+        $this->versionSupport = $versionSupport;
+        $this->codeDescriptionSupport = $codeDescriptionSupport;
+        $this->dataSupport = $dataSupport;
+    }
+}

--- a/src/PublishDiagnosticsClientCapabilitiesTagSupport.php
+++ b/src/PublishDiagnosticsClientCapabilitiesTagSupport.php
@@ -13,9 +13,9 @@ class PublishDiagnosticsClientCapabilitiesTagSupport
     public $valueSet;
 
     /**
-     * @param int[]|null $valueSet
+     * @param int[] $valueSet
      */
-    public function __construct(array $valueSet = null)
+    public function __construct(array $valueSet)
     {
         $this->valueSet = $valueSet;
     }

--- a/src/PublishDiagnosticsClientCapabilitiesTagSupport.php
+++ b/src/PublishDiagnosticsClientCapabilitiesTagSupport.php
@@ -13,10 +13,11 @@ class PublishDiagnosticsClientCapabilitiesTagSupport
     public $valueSet;
 
     /**
-     * @param int[] $valueSet
+     * @param int[]|null $valueSet
      */
-    public function __construct(array $valueSet)
+    public function __construct(array $valueSet = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->valueSet = $valueSet;
     }
 }

--- a/src/PublishDiagnosticsClientCapabilitiesTagSupport.php
+++ b/src/PublishDiagnosticsClientCapabilitiesTagSupport.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class PublishDiagnosticsClientCapabilitiesTagSupport
+{
+    /**
+     * The tags supported by the client.
+     *
+     * @var int[]
+     * @see DiagnosticTag
+     */
+    public $valueSet;
+
+    /**
+     * @param int[]|null $valueSet
+     */
+    public function __construct(array $valueSet = null)
+    {
+        $this->valueSet = $valueSet;
+    }
+}

--- a/src/Range.php
+++ b/src/Range.php
@@ -23,7 +23,9 @@ class Range
 
     public function __construct(Position $start = null, Position $end = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->start = $start;
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->end = $end;
     }
 

--- a/src/ReferenceClientCapabilities.php
+++ b/src/ReferenceClientCapabilities.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class ReferenceClientCapabilities
+{
+    /**
+     * Whether references supports dynamic registration.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    public function __construct(bool $dynamicRegistration = null)
+    {
+        $this->dynamicRegistration = $dynamicRegistration;
+    }
+}

--- a/src/ReferenceContext.php
+++ b/src/ReferenceContext.php
@@ -13,6 +13,7 @@ class ReferenceContext
 
     public function __construct(bool $includeDeclaration = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->includeDeclaration = $includeDeclaration;
     }
 }

--- a/src/ReferenceInformation.php
+++ b/src/ReferenceInformation.php
@@ -31,7 +31,9 @@ class ReferenceInformation
      */
     public function __construct(Location $reference = null, SymbolDescriptor $symbol = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->reference = $reference;
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->symbol = $symbol;
     }
 }

--- a/src/ReferenceInformation.php
+++ b/src/ReferenceInformation.php
@@ -26,7 +26,8 @@ class ReferenceInformation
 
     /**
      * @param Location         $reference The location in the workspace where the `symbol` is referenced.
-     * @param SymbolDescriptor $symbol    Metadata about the symbol that can be used to identify or locate its definition.
+     * @param SymbolDescriptor $symbol    Metadata about the symbol that
+     *                                    can be used to identify or locate its definition.
      */
     public function __construct(Location $reference = null, SymbolDescriptor $symbol = null)
     {

--- a/src/RegularExpressionsClientCapabilities.php
+++ b/src/RegularExpressionsClientCapabilities.php
@@ -5,24 +5,29 @@ namespace LanguageServerProtocol;
 class RegularExpressionsClientCapabilities
 {
 
-	/**
-	 * The engine's name.
-	 *
-	 * @var string
-	 */
-	public $engine;
+    /**
+     * The engine's name.
+     *
+     * @var string
+     */
+    public $engine;
 
-	/**
-	 * The engine's version.
-	 *
-	 * @var string|null
-	 */
-	public $version;
+    /**
+     * The engine's version.
+     *
+     * @var string|null
+     */
+    public $version;
 
 
-    public function __construct(string $engine, string $version = null)
-	{
-		$this->engine = $engine;
-		$this->version = $version;
-	}
+    /**
+     * @param string $engine
+     * @param string|null $version
+     */
+    public function __construct(string $engine = null, string $version = null)
+    {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
+        $this->engine = $engine;
+        $this->version = $version;
+    }
 }

--- a/src/RegularExpressionsClientCapabilities.php
+++ b/src/RegularExpressionsClientCapabilities.php
@@ -20,7 +20,7 @@ class RegularExpressionsClientCapabilities
 	public $version;
 
 
-    public function __construct(string $engine = null, string $version = null)
+    public function __construct(string $engine, string $version = null)
 	{
 		$this->engine = $engine;
 		$this->version = $version;

--- a/src/RegularExpressionsClientCapabilities.php
+++ b/src/RegularExpressionsClientCapabilities.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class RegularExpressionsClientCapabilities
+{
+
+	/**
+	 * The engine's name.
+	 *
+	 * @var string
+	 */
+	public $engine;
+
+	/**
+	 * The engine's version.
+	 *
+	 * @var string|null
+	 */
+	public $version;
+
+
+    public function __construct(string $engine = null, string $version = null)
+	{
+		$this->engine = $engine;
+		$this->version = $version;
+	}
+}

--- a/src/RenameClientCapabilities.php
+++ b/src/RenameClientCapabilities.php
@@ -59,7 +59,7 @@ class RenameClientCapabilities
         bool $prepareSupport = null,
         int $prepareSupportDefaultBehavior = null,
         bool $honorsChangeAnnotations = null
-    ){
+    ) {
         $this->dynamicRegistration = $dynamicRegistration;
         $this->prepareSupport = $prepareSupport;
         $this->prepareSupportDefaultBehavior = $prepareSupportDefaultBehavior;

--- a/src/RenameClientCapabilities.php
+++ b/src/RenameClientCapabilities.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class RenameClientCapabilities
+{
+
+    /**
+     * Whether text document synchronization supports dynamic registration.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    /**
+     * Client supports testing for validity of rename operations
+     * before execution.
+     *
+     * @since version 3.12.0
+     *
+     * @var bool|null
+     */
+    public $prepareSupport;
+
+    /**
+     * Client supports the default behavior result
+     * (`{ defaultBehavior: boolean }`).
+     *
+     * The value indicates the default behavior used by the
+     * client.
+     *
+     * @since version 3.16.0
+     *
+     * @var int|null
+     */
+    public $prepareSupportDefaultBehavior;
+
+    /**
+     * Whether th client honors the change annotations in
+     * text edits and resource operations returned via the
+     * rename request's workspace edit by for example presenting
+     * the workspace edit in the user interface and asking
+     * for confirmation.
+     *
+     * @since 3.16.0
+     *
+     * @var bool|null
+     */
+    public $honorsChangeAnnotations;
+
+    /**
+     * @param boolean|null $dynamicRegistration
+     * @param boolean|null $prepareSupport
+     * @param integer|null $prepareSupportDefaultBehavior PrepareSupportDefaultBehavior
+     * @param boolean|null $honorsChangeAnnotations
+     */
+    public function __construct(
+        bool $dynamicRegistration = null,
+        bool $prepareSupport = null,
+        int $prepareSupportDefaultBehavior = null,
+        bool $honorsChangeAnnotations = null
+    ){
+        $this->dynamicRegistration = $dynamicRegistration;
+        $this->prepareSupport = $prepareSupport;
+        $this->prepareSupportDefaultBehavior = $prepareSupportDefaultBehavior;
+        $this->honorsChangeAnnotations = $honorsChangeAnnotations;
+    }
+}

--- a/src/ResourceOperationKind.php
+++ b/src/ResourceOperationKind.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+/**
+ * Defines how the host (editor) should sync document changes to the language server.
+ */
+abstract class ResourceOperationKind
+{
+    /**
+     * Supports creating new files and folders.
+     */
+    const CREATE = 'create';
+
+    /**
+     * Supports renaming existing files and folders.
+     */
+    const RENAME = 'rename';
+
+    /**
+     * Supports deleting existing files and folders.
+     */
+    const DELETE  = 'delete';
+}

--- a/src/SelectionRangeClientCapabilities.php
+++ b/src/SelectionRangeClientCapabilities.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class SelectionRangeClientCapabilities
+{
+
+    /**
+     * Whether implementation supports dynamic registration for selection range
+     * providers. If this is set to `true` the client supports the new
+     * `SelectionRangeRegistrationOptions` return value for the corresponding
+     * server capability as well.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    public function __construct(bool $dynamicRegistration = null)
+    {
+        $this->dynamicRegistration = $dynamicRegistration;
+    }
+
+}

--- a/src/SelectionRangeClientCapabilities.php
+++ b/src/SelectionRangeClientCapabilities.php
@@ -19,5 +19,4 @@ class SelectionRangeClientCapabilities
     {
         $this->dynamicRegistration = $dynamicRegistration;
     }
-
 }

--- a/src/SemanticTokensClientCapabilities.php
+++ b/src/SemanticTokensClientCapabilities.php
@@ -95,10 +95,10 @@ class SemanticTokensClientCapabilities
     /**
      * Undocumented function
      *
-     * @param SemanticTokensClientCapabilitiesRequests $requests
-     * @param string[] $tokenTypes
-     * @param string[] $tokenModifiers
-     * @param string[] $formats
+     * @param SemanticTokensClientCapabilitiesRequests|null $requests
+     * @param string[]|null $tokenTypes
+     * @param string[]|null $tokenModifiers
+     * @param string[]|null $formats
      * @param boolean|null $dynamicRegistration
      * @param boolean|null $overlappingTokenSupport
      * @param boolean|null $multilineTokenSupport
@@ -106,19 +106,23 @@ class SemanticTokensClientCapabilities
      * @param boolean|null $augmentsSyntaxTokens
      */
     public function __construct(
-        SemanticTokensClientCapabilitiesRequests $requests,
-        array $tokenTypes,
-        array $tokenModifiers,
-        array $formats,
+        SemanticTokensClientCapabilitiesRequests $requests = null,
+        array $tokenTypes = null,
+        array $tokenModifiers = null,
+        array $formats = null,
         bool $dynamicRegistration = null,
         bool $overlappingTokenSupport = null,
         bool $multilineTokenSupport = null,
         bool $serverCancelSupport = null,
         bool $augmentsSyntaxTokens = null
     ) {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->requests = $requests;
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->tokenTypes = $tokenTypes;
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->tokenModifiers = $tokenModifiers;
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->formats = $formats;
         $this->dynamicRegistration = $dynamicRegistration;
         $this->overlappingTokenSupport = $overlappingTokenSupport;
@@ -126,5 +130,4 @@ class SemanticTokensClientCapabilities
         $this->serverCancelSupport = $serverCancelSupport;
         $this->augmentsSyntaxTokens = $augmentsSyntaxTokens;
     }
-
 }

--- a/src/SemanticTokensClientCapabilities.php
+++ b/src/SemanticTokensClientCapabilities.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class SemanticTokensClientCapabilities
+{
+/**
+     * Whether implementation supports dynamic registration. If this is set to
+     * `true` the client supports the new `(TextDocumentRegistrationOptions &
+     * StaticRegistrationOptions)` return value for the corresponding server
+     * capability as well.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    /**
+     * Which requests the client supports and might send to the server
+     * depending on the server's capability. Please note that clients might not
+     * show semantic tokens or degrade some of the user experience if a range
+     * or full request is advertised by the client but not provided by the
+     * server. If for example the client capability `requests.full` and
+     * `request.range` are both set to true but the server only provides a
+     * range provider the client might not render a minimap correctly or might
+     * even decide to not show any semantic tokens at all.
+     *
+     * @var SemanticTokensClientCapabilitiesRequests
+     */
+    public $requests;
+
+    /**
+     * The token types that the client supports.
+     *
+     * @var string[]
+     */
+    public $tokenTypes;
+
+    /**
+     * The token modifiers that the client supports.
+     *
+     * @var string[]
+     */
+    public $tokenModifiers;
+
+    /**
+     * The formats the clients supports.
+     *
+     * @var string[]
+     * @see TokenFormat
+     */
+    public $formats;
+
+    /**
+     * Whether the client supports tokens that can overlap each other.
+     *
+     * @var bool|null
+     */
+    public $overlappingTokenSupport;
+
+    /**
+     * Whether the client supports tokens that can span multiple lines.
+     *
+     * @var bool|null
+     */
+    public $multilineTokenSupport;
+
+    /**
+     * Whether the client allows the server to actively cancel a
+     * semantic token request, e.g. supports returning
+     * ErrorCodes.ServerCancelled. If a server does the client
+     * needs to retrigger the request.
+     *
+     * @since 3.17.0
+     *
+     * @var bool|null
+     */
+    public $serverCancelSupport;
+
+    /**
+     * Whether the client uses semantic tokens to augment existing
+     * syntax tokens. If set to `true` client side created syntax
+     * tokens and semantic tokens are both used for colorization. If
+     * set to `false` the client only uses the returned semantic tokens
+     * for colorization.
+     *
+     * If the value is `undefined` then the client behavior is not
+     * specified.
+     *
+     * @since 3.17.0
+     *
+     * @var bool|null
+     */
+    public $augmentsSyntaxTokens;
+
+    /**
+     * Undocumented function
+     *
+     * @param boolean|null $dynamicRegistration
+     * @param SemanticTokensClientCapabilitiesRequests|null $requests
+     * @param string[]|null $tokenTypes
+     * @param string[]|null $tokenModifiers
+     * @param string[]|null $formats
+     * @param boolean|null $overlappingTokenSupport
+     * @param boolean|null $multilineTokenSupport
+     * @param boolean|null $serverCancelSupport
+     * @param boolean|null $augmentsSyntaxTokens
+     */
+    public function __construct(
+        bool $dynamicRegistration = null,
+        SemanticTokensClientCapabilitiesRequests $requests = null,
+        array $tokenTypes = null,
+        array $tokenModifiers = null,
+        array $formats = null,
+        bool $overlappingTokenSupport = null,
+        bool $multilineTokenSupport = null,
+        bool $serverCancelSupport = null,
+        bool $augmentsSyntaxTokens = null
+    ) {
+        $this->dynamicRegistration = $dynamicRegistration;
+        $this->requests = $requests;
+        $this->tokenTypes = $tokenTypes;
+        $this->tokenModifiers = $tokenModifiers;
+        $this->formats = $formats;
+        $this->overlappingTokenSupport = $overlappingTokenSupport;
+        $this->multilineTokenSupport = $multilineTokenSupport;
+        $this->serverCancelSupport = $serverCancelSupport;
+        $this->augmentsSyntaxTokens = $augmentsSyntaxTokens;
+    }
+
+}

--- a/src/SemanticTokensClientCapabilities.php
+++ b/src/SemanticTokensClientCapabilities.php
@@ -95,32 +95,32 @@ class SemanticTokensClientCapabilities
     /**
      * Undocumented function
      *
+     * @param SemanticTokensClientCapabilitiesRequests $requests
+     * @param string[] $tokenTypes
+     * @param string[] $tokenModifiers
+     * @param string[] $formats
      * @param boolean|null $dynamicRegistration
-     * @param SemanticTokensClientCapabilitiesRequests|null $requests
-     * @param string[]|null $tokenTypes
-     * @param string[]|null $tokenModifiers
-     * @param string[]|null $formats
      * @param boolean|null $overlappingTokenSupport
      * @param boolean|null $multilineTokenSupport
      * @param boolean|null $serverCancelSupport
      * @param boolean|null $augmentsSyntaxTokens
      */
     public function __construct(
+        SemanticTokensClientCapabilitiesRequests $requests,
+        array $tokenTypes,
+        array $tokenModifiers,
+        array $formats,
         bool $dynamicRegistration = null,
-        SemanticTokensClientCapabilitiesRequests $requests = null,
-        array $tokenTypes = null,
-        array $tokenModifiers = null,
-        array $formats = null,
         bool $overlappingTokenSupport = null,
         bool $multilineTokenSupport = null,
         bool $serverCancelSupport = null,
         bool $augmentsSyntaxTokens = null
     ) {
-        $this->dynamicRegistration = $dynamicRegistration;
         $this->requests = $requests;
         $this->tokenTypes = $tokenTypes;
         $this->tokenModifiers = $tokenModifiers;
         $this->formats = $formats;
+        $this->dynamicRegistration = $dynamicRegistration;
         $this->overlappingTokenSupport = $overlappingTokenSupport;
         $this->multilineTokenSupport = $multilineTokenSupport;
         $this->serverCancelSupport = $serverCancelSupport;

--- a/src/SemanticTokensClientCapabilitiesRequests.php
+++ b/src/SemanticTokensClientCapabilitiesRequests.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class SemanticTokensClientCapabilitiesRequests
+{
+
+    /**
+     * The client will send the `textDocument/semanticTokens/range` request
+     * if the server provides a corresponding handler.
+     *
+     * @var mixed|null
+     */
+    public $range;
+
+    /**
+     * The client will send the `textDocument/semanticTokens/full` request
+     * if the server provides a corresponding handler.
+     *
+     * @var mixed|null
+     */
+    public $full;
+
+    public function __construct(
+        bool $range = null,
+        bool $full = null
+    ) {
+        $this->range = $range;
+        $this->full = $full;
+    }
+}

--- a/src/SemanticTokensWorkspaceClientCapabilities.php
+++ b/src/SemanticTokensWorkspaceClientCapabilities.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class SemanticTokensWorkspaceClientCapabilities
+{
+    /**
+     * Whether the client implementation supports a refresh request sent from
+     * the server to the client.
+     *
+     * Note that this event is global and will force the client to refresh all
+     * semantic tokens currently shown. It should be used with absolute care
+     * and is useful for situation where a server for example detect a project
+     * wide change that requires such a calculation.
+     *
+     * @var bool|null
+     */
+    public $refreshSupport;
+
+    public function __construct(bool $refreshSupport = null)
+    {
+        $this->refreshSupport = $refreshSupport;
+    }
+}

--- a/src/ServerCapabilities.php
+++ b/src/ServerCapabilities.php
@@ -128,11 +128,11 @@ class ServerCapabilities
     public $renameProvider;
 
     /**
-	 * The server provides execute command support.
+     * The server provides execute command support.
      *
      * @var ExecuteCommandOptions|null
-	 */
-	public $executeCommandProvider;
+     */
+    public $executeCommandProvider;
 
     /**
      * The server provides workspace references exporting support.

--- a/src/ServerCapabilities.php
+++ b/src/ServerCapabilities.php
@@ -128,6 +128,13 @@ class ServerCapabilities
     public $renameProvider;
 
     /**
+	 * The server provides execute command support.
+     *
+     * @var ExecuteCommandOptions|null
+	 */
+	public $executeCommandProvider;
+
+    /**
      * The server provides workspace references exporting support.
      *
      * @var bool|null

--- a/src/ShowDocumentClientCapabilities.php
+++ b/src/ShowDocumentClientCapabilities.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class ShowDocumentClientCapabilities
+{
+    /**
+     * The client has support for the show document
+     * request.
+     *
+     * @var bool|null
+     */
+    public $support;
+
+    public function __construct(?bool $support = null)
+    {
+        $this->support = $support;
+    }
+}

--- a/src/ShowMessageRequestClientCapabilities.php
+++ b/src/ShowMessageRequestClientCapabilities.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class ShowMessageRequestClientCapabilities
+{
+
+    /**
+     * Capabilities specific to the `MessageActionItem` type.
+     *
+     * @var ShowMessageRequestClientCapabilitiesMessageActionItem|null
+     */
+    public $messageActionItem;
+
+
+    public function __construct(ShowMessageRequestClientCapabilitiesMessageActionItem $messageActionItem = null)
+    {
+        $this->messageActionItem = $messageActionItem;
+    }
+}

--- a/src/ShowMessageRequestClientCapabilitiesMessageActionItem.php
+++ b/src/ShowMessageRequestClientCapabilitiesMessageActionItem.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class ShowMessageRequestClientCapabilitiesMessageActionItem
+{
+
+    /**
+     * Whether the client supports additional attributes which
+     * are preserved and sent back to the server in the
+     * request's response.
+     *
+     * @var bool|null
+     */
+    public $additionalPropertiesSupport;
+
+
+    public function __construct(bool $additionalPropertiesSupport = null)
+    {
+        $this->additionalPropertiesSupport = $additionalPropertiesSupport;
+    }
+}

--- a/src/SignatureHelp.php
+++ b/src/SignatureHelp.php
@@ -10,21 +10,36 @@ namespace LanguageServerProtocol;
 class SignatureHelp
 {
     /**
-     * One or more signatures.
+     * One or more signatures. If no signatures are available the signature help
+     * request should return `null`.
      *
-     * @var SignatureInformation[]
+     * @var SignatureInformation[]|null
      */
     public $signatures;
 
     /**
-     * The active signature.
+     * The active signature. If omitted or the value lies outside the
+     * range of `signatures` the value defaults to zero or is ignore if
+     * the `SignatureHelp` as no signatures.
+     *
+     * Whenever possible implementors should make an active decision about
+     * the active signature and shouldn't rely on a default value.
+     *
+     * In future version of the protocol this property might become
+     * mandatory to better express this.
      *
      * @var int|null
      */
     public $activeSignature;
 
     /**
-     * The active parameter of the active signature.
+     * The active parameter of the active signature. If omitted or the value
+     * lies outside the range of `signatures[activeSignature].parameters`
+     * defaults to 0 if the active signature has parameters. If
+     * the active signature has no parameters it is ignored.
+     * In future version of the protocol this property might become
+     * mandatory to better express the active parameter if the
+     * active signature does have any.
      *
      * @var int|null
      */
@@ -33,11 +48,11 @@ class SignatureHelp
     /**
      * Create a SignatureHelp
      *
-     * @param SignatureInformation[] $signatures      List of signature information
+     * @param SignatureInformation[]|null $signatures      List of signature information
      * @param int|null               $activeSignature The active signature, zero based
      * @param int|null               $activeParameter The active parameter, zero based
      */
-    public function __construct(array $signatures = [], $activeSignature = null, int $activeParameter = null)
+    public function __construct(array $signatures = null, $activeSignature = null, int $activeParameter = null)
     {
         $this->signatures = $signatures;
         $this->activeSignature = $activeSignature;

--- a/src/SignatureHelpClientCapabilities.php
+++ b/src/SignatureHelpClientCapabilities.php
@@ -2,7 +2,6 @@
 
 namespace LanguageServerProtocol;
 
-
 class SignatureHelpClientCapabilities
 {
     /**

--- a/src/SignatureHelpClientCapabilities.php
+++ b/src/SignatureHelpClientCapabilities.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+
+class SignatureHelpClientCapabilities
+{
+    /**
+     * Whether signature help supports dynamic registration.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    /**
+     * The client supports the following `SignatureInformation`
+     * specific properties.
+     *
+     * @var SignatureHelpClientCapabilitiesSignatureInformation|null
+     */
+    public $signatureInformation;
+
+    /**
+     * The client supports to send additional context information for a
+     * `textDocument/signatureHelp` request. A client that opts into
+     * contextSupport will also support the `retriggerCharacters` on
+     * `SignatureHelpOptions`.
+     *
+     * @since 3.15.0
+     *
+     * @var bool|null
+     */
+    public $contextSupport;
+
+    public function __construct(
+        bool $dynamicRegistration = null,
+        SignatureHelpClientCapabilitiesSignatureInformation $signatureInformation = null,
+        bool $contextSupport = null
+    ) {
+        $this->dynamicRegistration = $dynamicRegistration;
+        $this->signatureInformation = $signatureInformation;
+        $this->contextSupport = $contextSupport;
+    }
+}

--- a/src/SignatureHelpClientCapabilitiesSignatureInformation.php
+++ b/src/SignatureHelpClientCapabilitiesSignatureInformation.php
@@ -2,7 +2,6 @@
 
 namespace LanguageServerProtocol;
 
-
 class SignatureHelpClientCapabilitiesSignatureInformation
 {
 
@@ -43,7 +42,7 @@ class SignatureHelpClientCapabilitiesSignatureInformation
         array $documentationFormat = null,
         SignatureHelpClientCapabilitiesSignatureInformationParameterInformation $parameterInformation = null,
         bool $activeParameterSupport = null
-        ) {
+    ) {
         $this->documentationFormat = $documentationFormat;
         $this->parameterInformation = $parameterInformation;
         $this->activeParameterSupport = $activeParameterSupport;

--- a/src/SignatureHelpClientCapabilitiesSignatureInformation.php
+++ b/src/SignatureHelpClientCapabilitiesSignatureInformation.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+
+class SignatureHelpClientCapabilitiesSignatureInformation
+{
+
+    /**
+     * Client supports the follow content formats for the documentation
+     * property. The order describes the preferred format of the client.
+     *
+     * @var string[]|null
+     * @see MarkupKind
+     */
+    public $documentationFormat;
+
+    /**
+     * Client capabilities specific to parameter information.
+     *
+     * @var SignatureHelpClientCapabilitiesSignatureInformationParameterInformation|null
+     */
+    public $parameterInformation;
+
+    /**
+     * The client supports the `activeParameter` property on
+     * `SignatureInformation` literal.
+     *
+     * @since 3.16.0
+     *
+     * @var bool|null
+     */
+    public $activeParameterSupport;
+
+    /**
+     * Undocumented function
+     *
+     * @param string[]|null $documentationFormat
+     * @param SignatureHelpClientCapabilitiesSignatureInformationParameterInformation|null $parameterInformation
+     * @param boolean|null $activeParameterSupport
+     */
+    public function __construct(
+        array $documentationFormat = null,
+        SignatureHelpClientCapabilitiesSignatureInformationParameterInformation $parameterInformation = null,
+        bool $activeParameterSupport = null
+        ) {
+        $this->documentationFormat = $documentationFormat;
+        $this->parameterInformation = $parameterInformation;
+        $this->activeParameterSupport = $activeParameterSupport;
+    }
+}

--- a/src/SignatureHelpClientCapabilitiesSignatureInformationParameterInformation.php
+++ b/src/SignatureHelpClientCapabilitiesSignatureInformationParameterInformation.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+/**
+ * Client capabilities specific to parameter information.
+ */
+class SignatureHelpClientCapabilitiesSignatureInformationParameterInformation
+{
+    /**
+     * The client supports processing label offsets instead of a
+     * simple label string.
+     *
+     * @since 3.14.0
+     *
+     * @var bool|null
+     */
+    public $labelOffsetSupport;
+
+    public function __construct(bool $labelOffsetSupport = null)
+    {
+        $this->labelOffsetSupport = $labelOffsetSupport;
+    }
+}

--- a/src/SignatureInformation.php
+++ b/src/SignatureInformation.php
@@ -21,7 +21,7 @@ class SignatureInformation
      * The human-readable doc-comment of this signature. Will be shown
      * in the UI but can be omitted.
      *
-     * @var string|null
+     * @var MarkupContent|string|null
      */
     public $documentation;
 
@@ -33,17 +33,30 @@ class SignatureInformation
     public $parameters;
 
     /**
+	 * The index of the active parameter.
+	 *
+	 * If provided, this is used in place of `SignatureHelp.activeParameter`.
+	 *
+	 * @since 3.16.0
+     *
+     * @var int|null
+	 */
+	public $activeParameter;
+
+    /**
      * Create a SignatureInformation
      *
      * @param string $label                           The label of this signature. Will be shown in the UI.
      * @param ParameterInformation[]|null $parameters The parameters of this signature
-     * @param string|null $documentation              The human-readable doc-comment of this signature. Will be shown in the UI
+     * @param MarkupContent|string|null $documentation              The human-readable doc-comment of this signature. Will be shown in the UI
      *                                                but can be omitted.
+     * @param int|null $activeParameter The index of the active parameter.
      */
-    public function __construct(string $label, array $parameters = null, string $documentation = null)
+    public function __construct(string $label, array $parameters = null, $documentation = null, int $activeParameter = null)
     {
         $this->label = $label;
         $this->parameters = $parameters;
         $this->documentation = $documentation;
+        $this->activeParameter = $activeParameter;
     }
 }

--- a/src/SignatureInformation.php
+++ b/src/SignatureInformation.php
@@ -33,27 +33,31 @@ class SignatureInformation
     public $parameters;
 
     /**
-	 * The index of the active parameter.
-	 *
-	 * If provided, this is used in place of `SignatureHelp.activeParameter`.
-	 *
-	 * @since 3.16.0
+     * The index of the active parameter.
+     *
+     * If provided, this is used in place of `SignatureHelp.activeParameter`.
+     *
+     * @since 3.16.0
      *
      * @var int|null
-	 */
-	public $activeParameter;
+     */
+    public $activeParameter;
 
     /**
      * Create a SignatureInformation
      *
      * @param string $label                           The label of this signature. Will be shown in the UI.
      * @param ParameterInformation[]|null $parameters The parameters of this signature
-     * @param MarkupContent|string|null $documentation              The human-readable doc-comment of this signature. Will be shown in the UI
-     *                                                but can be omitted.
+     * @param MarkupContent|string|null $documentation  The human-readable doc-comment of this signature.
+     *                                                  Will be shown in the UI but can be omitted.
      * @param int|null $activeParameter The index of the active parameter.
      */
-    public function __construct(string $label, array $parameters = null, $documentation = null, int $activeParameter = null)
-    {
+    public function __construct(
+        string $label,
+        array $parameters = null,
+        $documentation = null,
+        int $activeParameter = null
+    ) {
         $this->label = $label;
         $this->parameters = $parameters;
         $this->documentation = $documentation;

--- a/src/SymbolDescriptor.php
+++ b/src/SymbolDescriptor.php
@@ -23,7 +23,8 @@ class SymbolDescriptor
     public $package;
 
     /**
-     * @param string $fqsen              The fully qualified structural element name, a globally unique identifier for the symbol.
+     * @param string $fqsen              The fully qualified structural element name, a globally
+     *                                   unique identifier for the symbol.
      * @param PackageDescriptor $package Identifies the Composer package the symbol is defined in
      */
     public function __construct(string $fqsen = null, PackageDescriptor $package = null)

--- a/src/SymbolDescriptor.php
+++ b/src/SymbolDescriptor.php
@@ -29,6 +29,7 @@ class SymbolDescriptor
      */
     public function __construct(string $fqsen = null, PackageDescriptor $package = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->fqsen = $fqsen;
         $this->package = $package;
     }

--- a/src/SymbolInformation.php
+++ b/src/SymbolInformation.php
@@ -44,8 +44,11 @@ class SymbolInformation
      */
     public function __construct($name = null, $kind = null, $location = null, $containerName = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->name = $name;
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->kind = $kind;
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->location = $location;
         $this->containerName = $containerName;
     }

--- a/src/SymbolLocationInformation.php
+++ b/src/SymbolLocationInformation.php
@@ -26,6 +26,7 @@ class SymbolLocationInformation
      */
     public function __construct(SymbolDescriptor $symbol = null, Location $location = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->symbol = $symbol;
         $this->location = $location;
     }

--- a/src/SymbolTag.php
+++ b/src/SymbolTag.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+/**
+ * Symbol tags are extra annotations that tweak the rendering of a symbol.
+ *
+ * @since 3.16
+ */
+abstract class SymbolTag
+{
+    /**
+     * Render a symbol as obsolete, usually using a strike-out.
+     */
+    const DEPRECATED = 1;
+}

--- a/src/TextDocumentClientCapabilities.php
+++ b/src/TextDocumentClientCapabilities.php
@@ -262,6 +262,4 @@ class TextDocumentClientCapabilities
         $this->semanticTokens = $semanticTokens;
         $this->moniker = $moniker;
     }
-
-
 }

--- a/src/TextDocumentClientCapabilities.php
+++ b/src/TextDocumentClientCapabilities.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class TextDocumentClientCapabilities
+{
+
+    /**
+     * @var TextDocumentSyncClientCapabilities|null
+     */
+    public $synchronization;
+
+    /**
+     * Capabilities specific to the `textDocument/completion` request.
+     *
+     * @var CompletionClientCapabilities|null
+     */
+    public $completion;
+
+    /**
+     * Capabilities specific to the `textDocument/hover` request.
+     *
+     * @var HoverClientCapabilities|null
+     */
+    public $hover;
+
+    /**
+     * Capabilities specific to the `textDocument/signatureHelp` request.
+     *
+     * @var SignatureHelpClientCapabilities|null
+     */
+    public $signatureHelp;
+
+    /**
+     * Capabilities specific to the `textDocument/declaration` request.
+     *
+     * @since 3.14.0
+     *
+     * @var DeclarationClientCapabilities|null
+     */
+    public $declaration;
+
+    /**
+     * Capabilities specific to the `textDocument/definition` request.
+     *
+     * @var DefinitionClientCapabilities|null
+     */
+    public $definition;
+
+    /**
+     * Capabilities specific to the `textDocument/typeDefinition` request.
+     *
+     * @since 3.6.0
+     *
+     * @var TypeDefinitionClientCapabilities|null
+     */
+    public $typeDefinition;
+
+    /**
+     * Capabilities specific to the `textDocument/implementation` request.
+     *
+     * @since 3.6.0
+     *
+     * @var ImplementationClientCapabilities|null
+     */
+    public $implementation;
+
+    /**
+     * Capabilities specific to the `textDocument/references` request.
+     *
+     * @var ReferenceClientCapabilities|null
+     */
+    public $references;
+
+    /**
+     * Capabilities specific to the `textDocument/documentHighlight` request.
+     *
+     * @var DocumentHighlightClientCapabilities|null
+     */
+    public $documentHighlight;
+
+    /**
+     * Capabilities specific to the `textDocument/documentSymbol` request.
+     *
+     * @var DocumentSymbolClientCapabilities|null
+     */
+    public $documentSymbol;
+
+    /**
+     * Capabilities specific to the `textDocument/codeAction` request.
+     *
+     * @var CodeActionClientCapabilities|null
+     */
+    public $codeAction;
+
+    /**
+     * Capabilities specific to the `textDocument/codeLens` request.
+     *
+     * @var CodeLensClientCapabilities|null
+     */
+    public $codeLens;
+
+    /**
+     * Capabilities specific to the `textDocument/documentLink` request.
+     *
+     * @var DocumentLinkClientCapabilities|null
+     */
+    public $documentLink;
+
+    /**
+     * Capabilities specific to the `textDocument/documentColor` and the
+     * `textDocument/colorPresentation` request.
+     *
+     * @since 3.6.0
+     *
+     * @var DocumentColorClientCapabilities|null
+     */
+    public $colorProvider;
+
+    /**
+     * Capabilities specific to the `textDocument/formatting` request.
+     *
+     * @var DocumentFormattingClientCapabilities|null
+     */
+    public $formatting;
+
+    /**
+     * Capabilities specific to the `textDocument/rangeFormatting` request.
+     *
+     * @var DocumentRangeFormattingClientCapabilities|null
+     */
+    public $rangeFormatting;
+
+    /** request.
+     * Capabilities specific to the `textDocument/onTypeFormatting` request.
+     *
+     * @var DocumentOnTypeFormattingClientCapabilities|null
+     */
+    public $onTypeFormatting;
+
+    /**
+     * Capabilities specific to the `textDocument/rename` request.
+     *
+     * @var RenameClientCapabilities|null
+     */
+    public $rename;
+
+    /**
+     * Capabilities specific to the `textDocument/publishDiagnostics`
+     * notification.
+     *
+     * @var PublishDiagnosticsClientCapabilities|null
+     */
+    public $publishDiagnostics;
+
+    /**
+     * Capabilities specific to the `textDocument/foldingRange` request.
+     *
+     * @since 3.10.0
+     *
+     * @var FoldingRangeClientCapabilities|null
+     */
+    public $foldingRange;
+
+    /**
+     * Capabilities specific to the `textDocument/selectionRange` request.
+     *
+     * @since 3.15.0
+     *
+     * @var SelectionRangeClientCapabilities|null
+     */
+    public $selectionRange;
+
+    /**
+     * Capabilities specific to the `textDocument/linkedEditingRange` request.
+     *
+     * @since 3.16.0
+     *
+     * @var LinkedEditingRangeClientCapabilities|null
+     */
+    public $linkedEditingRange;
+
+    /**
+     * Capabilities specific to the various call hierarchy requests.
+     *
+     * @since 3.16.0
+     *
+     * @var CallHierarchyClientCapabilities|null
+     */
+    public $callHierarchy;
+
+    /**
+     * Capabilities specific to the various semantic token requests.
+     *
+     * @since 3.16.0
+     *
+     * @var SemanticTokensClientCapabilities|null
+     */
+    public $semanticTokens;
+
+    /**
+     * Capabilities specific to the `textDocument/moniker` request.
+     *
+     * @since 3.16.0
+     *
+     * @var MonikerClientCapabilities|null
+     */
+    public $moniker;
+
+    public function __construct(
+        TextDocumentSyncClientCapabilities $synchronization = null,
+        CompletionClientCapabilities $completion = null,
+        HoverClientCapabilities $hover = null,
+        SignatureHelpClientCapabilities $signatureHelp = null,
+        DeclarationClientCapabilities $declaration = null,
+        DefinitionClientCapabilities $definition = null,
+        TypeDefinitionClientCapabilities $typeDefinition = null,
+        ImplementationClientCapabilities $implementation = null,
+        ReferenceClientCapabilities $references = null,
+        DocumentHighlightClientCapabilities $documentHighlight = null,
+        DocumentSymbolClientCapabilities $documentSymbol = null,
+        CodeActionClientCapabilities $codeAction = null,
+        CodeLensClientCapabilities $codeLens = null,
+        DocumentLinkClientCapabilities $documentLink = null,
+        DocumentColorClientCapabilities $colorProvider = null,
+        DocumentFormattingClientCapabilities $formatting = null,
+        DocumentRangeFormattingClientCapabilities $rangeFormatting = null,
+        DocumentOnTypeFormattingClientCapabilities $onTypeFormatting = null,
+        RenameClientCapabilities $rename = null,
+        PublishDiagnosticsClientCapabilities $publishDiagnostics = null,
+        FoldingRangeClientCapabilities $foldingRange = null,
+        SelectionRangeClientCapabilities $selectionRange = null,
+        LinkedEditingRangeClientCapabilities $linkedEditingRange = null,
+        CallHierarchyClientCapabilities $callHierarchy = null,
+        SemanticTokensClientCapabilities $semanticTokens = null,
+        MonikerClientCapabilities $moniker = null
+    ) {
+        $this->synchronization = $synchronization;
+        $this->completion = $completion;
+        $this->hover = $hover;
+        $this->signatureHelp = $signatureHelp;
+        $this->declaration = $declaration;
+        $this->definition = $definition;
+        $this->typeDefinition = $typeDefinition;
+        $this->implementation = $implementation;
+        $this->references = $references;
+        $this->documentHighlight = $documentHighlight;
+        $this->documentSymbol = $documentSymbol;
+        $this->codeAction = $codeAction;
+        $this->codeLens = $codeLens;
+        $this->documentLink = $documentLink;
+        $this->colorProvider = $colorProvider;
+        $this->formatting = $formatting;
+        $this->rangeFormatting = $rangeFormatting;
+        $this->onTypeFormatting = $onTypeFormatting;
+        $this->rename = $rename;
+        $this->publishDiagnostics = $publishDiagnostics;
+        $this->foldingRange = $foldingRange;
+        $this->selectionRange = $selectionRange;
+        $this->linkedEditingRange = $linkedEditingRange;
+        $this->callHierarchy = $callHierarchy;
+        $this->semanticTokens = $semanticTokens;
+        $this->moniker = $moniker;
+    }
+
+
+}

--- a/src/TextDocumentContentChangeEvent.php
+++ b/src/TextDocumentContentChangeEvent.php
@@ -33,6 +33,7 @@ class TextDocumentContentChangeEvent
     {
         $this->range = $range;
         $this->rangeLength = $rangeLength;
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->text = $text;
     }
 }

--- a/src/TextDocumentIdentifier.php
+++ b/src/TextDocumentIdentifier.php
@@ -16,6 +16,7 @@ class TextDocumentIdentifier
      */
     public function __construct(string $uri = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->uri = $uri;
     }
 }

--- a/src/TextDocumentItem.php
+++ b/src/TextDocumentItem.php
@@ -38,9 +38,13 @@ class TextDocumentItem
 
     public function __construct(string $uri = null, string $languageId = null, int $version = null, string $text = null)
     {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->uri = $uri;
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->languageId = $languageId;
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->version = $version;
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->text = $text;
     }
 }

--- a/src/TextDocumentSyncClientCapabilities.php
+++ b/src/TextDocumentSyncClientCapabilities.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class TextDocumentSyncClientCapabilities
+{
+
+    /**
+     * Whether text document synchronization supports dynamic registration.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    /**
+     * The client supports sending will save notifications.
+     *
+     * @var bool|null
+     */
+    public $willSave;
+
+    /**
+     * The client supports sending a will save request and
+     * waits for a response providing text edits which will
+     * be applied to the document before it is saved.
+     *
+     * @var bool|null
+     */
+    public $willSaveWaitUntil;
+
+    /**
+     * The client supports did save notifications.
+     *
+     * @var bool|null
+     */
+    public $didSave;
+
+    public function __construct(
+        bool $dynamicRegistration = null,
+        bool $willSave = null,
+        bool $willSaveWaitUntil = null,
+        bool $didSave = null
+    ){
+        $this->dynamicRegistration = $dynamicRegistration;
+        $this->willSave = $willSave;
+        $this->willSaveWaitUntil = $willSaveWaitUntil;
+        $this->didSave = $didSave;
+    }
+}

--- a/src/TextDocumentSyncClientCapabilities.php
+++ b/src/TextDocumentSyncClientCapabilities.php
@@ -40,7 +40,7 @@ class TextDocumentSyncClientCapabilities
         bool $willSave = null,
         bool $willSaveWaitUntil = null,
         bool $didSave = null
-    ){
+    ) {
         $this->dynamicRegistration = $dynamicRegistration;
         $this->willSave = $willSave;
         $this->willSaveWaitUntil = $willSaveWaitUntil;

--- a/src/TokenFormat.php
+++ b/src/TokenFormat.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+abstract class TokenFormat
+{
+    const RELATIVE = 'relative';
+}

--- a/src/TypeDefinitionClientCapabilities.php
+++ b/src/TypeDefinitionClientCapabilities.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class TypeDefinitionClientCapabilities
+{
+
+    /**
+     * Whether implementation supports dynamic registration. If this is set to
+     * `true` the client supports the new `TypeDefinitionRegistrationOptions`
+     * return value for the corresponding server capability as well.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+    /**
+     * The client supports additional metadata in the form of definition links.
+     *
+     * @since 3.14.0
+     *
+     * @var boolean|null
+     */
+    public $linkSupport;
+
+    public function __construct(
+        bool $dynamicRegistration = null,
+        bool $linkSupport = null
+    ) {
+        $this->dynamicRegistration = $dynamicRegistration;
+        $this->linkSupport = $linkSupport;
+    }
+}

--- a/src/WorkspaceEdit.php
+++ b/src/WorkspaceEdit.php
@@ -2,10 +2,12 @@
 
 namespace LanguageServerProtocol;
 
+use JsonSerializable;
+
 /**
  * A workspace edit represents changes to many resources managed in the workspace.
  */
-class WorkspaceEdit
+class WorkspaceEdit implements JsonSerializable
 {
     /**
      * Holds changes to existing resources. Associative Array from URI to TextEdit
@@ -60,5 +62,17 @@ class WorkspaceEdit
         $this->changes = $changes;
         $this->documentChanges = $documentChanges;
         $this->changeAnnotations = $changeAnnotations;
+    }
+
+    /**
+     * This is needed because VSCode Does not like nulls
+     * meaning if a null is sent then this will not compute
+     *
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+        return array_filter(get_object_vars($this));
     }
 }

--- a/src/WorkspaceEdit.php
+++ b/src/WorkspaceEdit.php
@@ -49,11 +49,13 @@ class WorkspaceEdit
 
     /**
      * @param array<string, TextEdit[]> $changes
+     * @param mixed $documentChanges
+     * @param array<string, ChangeAnnotation>|null $changeAnnotations
      */
     public function __construct(
         array $changes = [],
         $documentChanges = null,
-        array $changeAnnotations = []
+        array $changeAnnotations = null
     ) {
         $this->changes = $changes;
         $this->documentChanges = $documentChanges;

--- a/src/WorkspaceEdit.php
+++ b/src/WorkspaceEdit.php
@@ -10,15 +10,53 @@ class WorkspaceEdit
     /**
      * Holds changes to existing resources. Associative Array from URI to TextEdit
      *
-     * @var TextEdit[]
+     * @var array<string, TextEdit[]>
      */
     public $changes;
 
     /**
-     * @param TextEdit[] $changes
+     * Depending on the client capability
+     * `workspace.workspaceEdit.resourceOperations` document changes are either
+     * an array of `TextDocumentEdit`s to express changes to n different text
+     * documents where each text document edit addresses a specific version of
+     * a text document. Or it can contain above `TextDocumentEdit`s mixed with
+     * create, rename and delete file / folder operations.
+     *
+     * Whether a client supports versioned document edits is expressed via
+     * `workspace.workspaceEdit.documentChanges` client capability.
+     *
+     * If a client neither supports `documentChanges` nor
+     * `workspace.workspaceEdit.resourceOperations` then only plain `TextEdit`s
+     * using the `changes` property are supported.
+     *
+     * @var mixed
      */
-    public function __construct(array $changes = [])
-    {
+    public $documentChanges;
+
+    /**
+     * A map of change annotations that can be referenced in
+     * `AnnotatedTextEdit`s or create, rename and delete file / folder
+     * operations.
+     *
+     * Whether clients honor this property depends on the client capability
+     * `workspace.changeAnnotationSupport`.
+     *
+     * @since 3.16.0
+     *
+     * @var array<string, ChangeAnnotation>|null
+     */
+    public $changeAnnotations;
+
+    /**
+     * @param array<string, TextEdit[]> $changes
+     */
+    public function __construct(
+        array $changes = [],
+        $documentChanges = null,
+        array $changeAnnotations = []
+    ) {
         $this->changes = $changes;
+        $this->documentChanges = $documentChanges;
+        $this->changeAnnotations = $changeAnnotations;
     }
 }

--- a/src/WorkspaceEditClientCapabilities.php
+++ b/src/WorkspaceEditClientCapabilities.php
@@ -55,6 +55,15 @@ class WorkspaceEditClientCapabilities
      */
     public $changeAnnotationSupport;
 
+    /**
+     * Undocumented function
+     *
+     * @param boolean|null $documentChanges
+     * @param string[]|null $resourceOperations
+     * @param string|null $failureHandling
+     * @param boolean|null $normalizesLineEndings
+     * @param WorkspaceEditClientCapabilitiesChangeAnnotationSupport|null $changeAnnotationSupport
+     */
     public function __construct(
         bool $documentChanges = null,
         array $resourceOperations = null,

--- a/src/WorkspaceEditClientCapabilities.php
+++ b/src/WorkspaceEditClientCapabilities.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class WorkspaceEditClientCapabilities
+{
+    /**
+     * The client supports versioned document changes in `WorkspaceEdit`s
+     *
+     * @var bool|null
+     */
+    public $documentChanges;
+
+    /**
+     * The resource operations the client supports. Clients should at least
+     * support 'create', 'rename' and 'delete' files and folders.
+     *
+     * @since 3.13.0
+     *
+     * @var string[]|null
+     * @see ResourceOperationKind
+     */
+    public $resourceOperations;
+
+    /**
+     * The failure handling strategy of a client if applying the workspace edit
+     * fails.
+     *
+     * @since 3.13.0
+     *
+     * @var string|null
+     * @see FailureHandlingKind
+     */
+    public $failureHandling;
+
+    /**
+     * Whether the client normalizes line endings to the client specific
+     * setting.
+     * If set to `true` the client will normalize line ending characters
+     * in a workspace edit to the client specific new line character(s).
+     *
+     * @since 3.16.0
+     *
+     * @var bool|null
+     */
+    public $normalizesLineEndings;
+
+    /**
+     * Whether the client in general supports change annotations on text edits,
+     * create file, rename file and delete file changes.
+     *
+     * @since 3.16.0
+     *
+     * @var WorkspaceEditClientCapabilitiesChangeAnnotationSupport|null
+     */
+    public $changeAnnotationSupport;
+
+    public function __construct(
+        bool $documentChanges = null,
+        array $resourceOperations = null,
+        string $failureHandling = null,
+        bool $normalizesLineEndings = null,
+        WorkspaceEditClientCapabilitiesChangeAnnotationSupport $changeAnnotationSupport = null
+    ) {
+        $this->documentChanges = $documentChanges;
+        $this->resourceOperations = $resourceOperations;
+        $this->failureHandling = $failureHandling;
+        $this->normalizesLineEndings = $normalizesLineEndings;
+        $this->changeAnnotationSupport = $changeAnnotationSupport;
+    }
+}

--- a/src/WorkspaceEditClientCapabilitiesChangeAnnotationSupport.php
+++ b/src/WorkspaceEditClientCapabilitiesChangeAnnotationSupport.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class WorkspaceEditClientCapabilitiesChangeAnnotationSupport
+{
+    /**
+     * Whether the client groups edits with equal labels into tree nodes,
+     * for instance all edits labelled with "Changes in Strings" would
+     * be a tree node.
+     *
+     * @var bool|null
+     */
+    public $groupsOnLabel;
+
+    public function __construct(
+        bool $groupsOnLabel = null
+    ) {
+        $this->groupsOnLabel = $groupsOnLabel;
+    }
+}

--- a/src/WorkspaceFolder.php
+++ b/src/WorkspaceFolder.php
@@ -18,4 +18,12 @@ class WorkspaceFolder
      * @var string
      */
     public $name;
+
+    PUblic function __construct(
+        string $uri,
+        string $name
+    ) {
+        $this->uri = $uri;
+        $this->name = $name;
+    }
 }

--- a/src/WorkspaceFolder.php
+++ b/src/WorkspaceFolder.php
@@ -19,11 +19,13 @@ class WorkspaceFolder
      */
     public $name;
 
-    PUblic function __construct(
-        string $uri,
-        string $name
+    public function __construct(
+        string $uri = null,
+        string $name = null
     ) {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->uri = $uri;
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->name = $name;
     }
 }

--- a/src/WorkspaceFolder.php
+++ b/src/WorkspaceFolder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class WorkspaceFolder
+{
+    /**
+     * The associated URI for this workspace folder.
+     *
+     * @var string
+     */
+    public $uri;
+
+    /**
+     * The name of the workspace folder. Used to refer to this
+     * workspace folder in the user interface.
+     *
+     * @var string
+     */
+    public $name;
+}

--- a/src/WorkspaceSymbolClientCapabilities.php
+++ b/src/WorkspaceSymbolClientCapabilities.php
@@ -12,44 +12,44 @@ class WorkspaceSymbolClientCapabilities
      */
     public $dynamicRegistration;
 
-	/**
-	 * Specific capabilities for the `SymbolKind` in the `workspace/symbol`
-	 * request.
-	 *
-	 * @var WorkspaceSymbolClientCapabilitiesSymbolKind|null
-	 */
-	public $symbolKind;
+    /**
+     * Specific capabilities for the `SymbolKind` in the `workspace/symbol`
+     * request.
+     *
+     * @var WorkspaceSymbolClientCapabilitiesSymbolKind|null
+     */
+    public $symbolKind;
 
-	/**
-	 * The client supports tags on `SymbolInformation` and `WorkspaceSymbol`.
-	 * Clients supporting tags have to handle unknown tags gracefully.
-	 *
-	 * @since 3.16.0
-	 *
-	 * @var WorkspaceSymbolClientCapabilitiesTagSupport|null
-	 */
-	public $tagSupport;
+    /**
+     * The client supports tags on `SymbolInformation` and `WorkspaceSymbol`.
+     * Clients supporting tags have to handle unknown tags gracefully.
+     *
+     * @since 3.16.0
+     *
+     * @var WorkspaceSymbolClientCapabilitiesTagSupport|null
+     */
+    public $tagSupport;
 
-	/**
-	 * The client support partial workspace symbols. The client will send the
-	 * request `workspaceSymbol/resolve` to the server to resolve additional
-	 * properties.
-	 *
-	 * @since 3.17.0 - proposedState
-	 *
-	 * @var WorkspaceSymbolClientCapabilitiesResolveSupport|null
-	 */
-	public $resolveSupport;
+    /**
+     * The client support partial workspace symbols. The client will send the
+     * request `workspaceSymbol/resolve` to the server to resolve additional
+     * properties.
+     *
+     * @since 3.17.0 - proposedState
+     *
+     * @var WorkspaceSymbolClientCapabilitiesResolveSupport|null
+     */
+    public $resolveSupport;
 
-	public function __construct(
-		bool $dynamicRegistration = null,
-		WorkspaceSymbolClientCapabilitiesSymbolKind $symbolKind = null,
-		WorkspaceSymbolClientCapabilitiesTagSupport $tagSupport = null,
-		WorkspaceSymbolClientCapabilitiesResolveSupport $resolveSupport = null
-	) {
-		$this->dynamicRegistration = $dynamicRegistration;
-		$this->symbolKind = $symbolKind;
-		$this->tagSupport = $tagSupport;
-		$this->resolveSupport = $resolveSupport;
-	}
+    public function __construct(
+        bool $dynamicRegistration = null,
+        WorkspaceSymbolClientCapabilitiesSymbolKind $symbolKind = null,
+        WorkspaceSymbolClientCapabilitiesTagSupport $tagSupport = null,
+        WorkspaceSymbolClientCapabilitiesResolveSupport $resolveSupport = null
+    ) {
+        $this->dynamicRegistration = $dynamicRegistration;
+        $this->symbolKind = $symbolKind;
+        $this->tagSupport = $tagSupport;
+        $this->resolveSupport = $resolveSupport;
+    }
 }

--- a/src/WorkspaceSymbolClientCapabilities.php
+++ b/src/WorkspaceSymbolClientCapabilities.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class WorkspaceSymbolClientCapabilities
+{
+
+    /**
+     * Symbol request supports dynamic registration.
+     *
+     * @var bool|null
+     */
+    public $dynamicRegistration;
+
+	/**
+	 * Specific capabilities for the `SymbolKind` in the `workspace/symbol`
+	 * request.
+	 *
+	 * @var WorkspaceSymbolClientCapabilitiesSymbolKind|null
+	 */
+	public $symbolKind;
+
+	/**
+	 * The client supports tags on `SymbolInformation` and `WorkspaceSymbol`.
+	 * Clients supporting tags have to handle unknown tags gracefully.
+	 *
+	 * @since 3.16.0
+	 *
+	 * @var WorkspaceSymbolClientCapabilitiesTagSupport|null
+	 */
+	public $tagSupport;
+
+	/**
+	 * The client support partial workspace symbols. The client will send the
+	 * request `workspaceSymbol/resolve` to the server to resolve additional
+	 * properties.
+	 *
+	 * @since 3.17.0 - proposedState
+	 *
+	 * @var WorkspaceSymbolClientCapabilitiesResolveSupport|null
+	 */
+	public $resolveSupport;
+
+	public function __construct(
+		bool $dynamicRegistration = null,
+		WorkspaceSymbolClientCapabilitiesSymbolKind $symbolKind = null,
+		WorkspaceSymbolClientCapabilitiesTagSupport $tagSupport = null,
+		WorkspaceSymbolClientCapabilitiesResolveSupport $resolveSupport = null
+	) {
+		$this->dynamicRegistration = $dynamicRegistration;
+		$this->symbolKind = $symbolKind;
+		$this->tagSupport = $tagSupport;
+		$this->resolveSupport = $resolveSupport;
+	}
+}

--- a/src/WorkspaceSymbolClientCapabilitiesResolveSupport.php
+++ b/src/WorkspaceSymbolClientCapabilitiesResolveSupport.php
@@ -16,8 +16,9 @@ class WorkspaceSymbolClientCapabilitiesResolveSupport
      * @param string[] $properties
      */
     public function __construct(
-        array $properties
+        array $properties = null
     ) {
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue */
         $this->properties = $properties;
     }
 }

--- a/src/WorkspaceSymbolClientCapabilitiesResolveSupport.php
+++ b/src/WorkspaceSymbolClientCapabilitiesResolveSupport.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class WorkspaceSymbolClientCapabilitiesResolveSupport
+{
+    /**
+     * The properties that a client can resolve lazily. Usually
+     * `location.range`
+     *
+     * @var string[]
+     */
+    public $properties;
+
+     /**
+     * @param string[] $properties
+     */
+    public function __construct(
+        array $properties
+    ) {
+        $this->properties = $properties;
+    }
+}

--- a/src/WorkspaceSymbolClientCapabilitiesSymbolKind.php
+++ b/src/WorkspaceSymbolClientCapabilitiesSymbolKind.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class WorkspaceSymbolClientCapabilitiesSymbolKind
+{
+    /**
+     * The symbol kind values the client supports. When this
+     * property exists the client also guarantees that it will
+     * handle values outside its set gracefully and falls back
+     * to a default value when unknown.
+     *
+     * If this property is not present the client only supports
+     * the symbol kinds from `File` to `Array` as defined in
+     * the initial version of the protocol.
+     *
+     * @var int[]|null
+     * @see SymbolKind
+     */
+    public $valueSet;
+
+    /**
+     * @param int[]|null $valueSet
+     */
+    public function __construct(
+        array $valueSet = null
+    ) {
+        $this->valueSet = $valueSet;
+    }
+}

--- a/src/WorkspaceSymbolClientCapabilitiesTagSupport.php
+++ b/src/WorkspaceSymbolClientCapabilitiesTagSupport.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace LanguageServerProtocol;
+
+class WorkspaceSymbolClientCapabilitiesTagSupport
+{
+    /**
+     * The symbol kind values the client supports. When this
+     * property exists the client also guarantees that it will
+     * handle values outside its set gracefully and falls back
+     * to a default value when unknown.
+     *
+     * If this property is not present the client only supports
+     * the symbol kinds from `File` to `Array` as defined in
+     * the initial version of the protocol.
+     *
+     * @var int[]|null
+     * @see SymbolTag
+     */
+    public $valueSet;
+
+    /**
+     * @param int[]|null $valueSet
+     */
+    public function __construct(
+        array $valueSet = null
+    ) {
+        $this->valueSet = $valueSet;
+    }
+}


### PR DESCRIPTION
I added psalm in github actions.

Also Psalm has strict requirements on some of the class constructors not allowing nulls. I am not sure how this will interact with json-rpc-dispatcher since that uses jsonmapper to construct the classes (but it uses reflection). Just have not tested this yet.

Note I changed your class name of WindowClientCapabilities to ClientCapabilitiesWindow.

Additional notes:

I maintain:

- https://github.com/psalm/psalm-vscode-plugin
- Psalm (https://github.com/vimeo/psalm) uses this library for it's own Language server which overlaps slightly with the language server you forked
- I also do some maintenance on the LSP in Psalm and additionally I'm working on reworking it here: https://github.com/tm1000/psalm/tree/feature/upgrade-lsp for the v5 release of Psalm